### PR TITLE
Move over json-lint from graphql/graphiql

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "babel": "5.8.23",
     "babel-core": "5.8.23",
     "babel-eslint": "4.0.10",
+    "babel-runtime": "^5.8.20",
     "chai": "3.2.0",
     "chai-subset": "1.0.1",
     "codemirror": "5.6.0",

--- a/src/__tests__/json-lint-test.js
+++ b/src/__tests__/json-lint-test.js
@@ -1,0 +1,63 @@
+/**
+ *  Copyright (c) 2015, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the license found in the
+ *  LICENSE-examples file in the root directory of this source tree.
+ */
+
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import CodeMirror from 'codemirror';
+import 'codemirror/mode/javascript/javascript';
+import 'codemirror/addon/lint/lint';
+import '../json-lint';
+
+/* eslint-disable max-len */
+
+function createEditorWithLint() {
+  return CodeMirror(document.createElement('div'), {
+    mode: {
+      name: 'javascript',
+      json: true
+    },
+    lint: true
+  });
+}
+
+function printLintErrors(queryString) {
+  var editor = createEditorWithLint();
+
+  return new Promise((resolve, reject) => {
+    editor.state.lint.options.onUpdateLinting = (errors) => {
+      if (errors && errors[0]) {
+        if (!errors[0].message.match('Unexpected EOF')) {
+          resolve(errors);
+        }
+      }
+      reject();
+    };
+    editor.doc.setValue(queryString);
+  }).then((errors) => {
+    return errors;
+  }).catch(() => {
+    return [];
+  });
+}
+
+describe('graphql-json-lint', () => {
+
+  it('attaches a GraphQL lint function with correct mode/lint options', () => {
+    var editor = createEditorWithLint();
+    expect(
+      editor.getHelpers(editor.getCursor(), 'lint')
+    ).to.not.have.lengthOf(0);
+  });
+
+  it('catches syntax errors', async () => {
+    expect(
+      (await printLintErrors(`x`))[0].message
+    ).to.contain('Expected { but got x.');
+  });
+
+});

--- a/src/json-lint.js
+++ b/src/json-lint.js
@@ -1,0 +1,268 @@
+/**
+ *  Copyright (c) 2015, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the license found in the
+ *  LICENSE-examples file in the root directory of this source tree.
+ */
+
+import CodeMirror from 'codemirror';
+
+CodeMirror.registerHelper('lint', 'json', text => {
+  var err = jsonLint(text);
+  if (err) {
+    return [ {
+      message: err.message,
+      severity: 'error',
+      from: getLocation(text, err.start),
+      to: getLocation(text, err.end)
+    } ];
+  }
+  return [];
+});
+
+function getLocation(source, position) {
+  var line = 0;
+  var column = position;
+  var lineRegexp = /\r\n|[\n\r]/g;
+  var match;
+  while ((match = lineRegexp.exec(source)) && match.index < position) {
+    line += 1;
+    column = position - (match.index + match[0].length);
+  }
+  return CodeMirror.Pos(line, column);
+}
+
+/**
+ * This JSON parser simply walks the input, but does not generate an AST
+ * or Value. Instead it returns either an syntax error object, or null.
+ *
+ * The returned syntax error object:
+ *
+ *   - message: string
+ *   - start: int - the start inclusive offset of the syntax error
+ *   - end: int - the end exclusive offset of the syntax error
+ *
+ */
+function jsonLint(str, looseMode) {
+  string = str;
+  strLen = str.length;
+  end = -1;
+  try {
+    ch();
+    lex();
+    if (looseMode) {
+      readVal();
+    } else {
+      readObj();
+    }
+    expect('EOF');
+  } catch (err) {
+    return err;
+  }
+}
+
+var string;
+var strLen;
+var start;
+var end;
+var code;
+var kind;
+
+function readObj() {
+  expect('{');
+  if (!skip('}')) {
+    do {
+      expect('String');
+      expect(':');
+      readVal();
+    } while (skip(','));
+    expect('}');
+  }
+}
+
+function readArr() {
+  expect('[');
+  if (!skip(']')) {
+    do {
+      readVal();
+    } while (skip(','));
+    expect(']');
+  }
+}
+
+function readVal() {
+  switch (kind) {
+    case '[': return readArr();
+    case '{': return readObj();
+    case 'String': return lex();
+    default: return expect('Value');
+  }
+}
+
+function syntaxError(message) {
+  return { message, start, end };
+}
+
+function expect(str) {
+  if (kind === str) {
+    return lex();
+  }
+  throw syntaxError(`Expected ${str} but got ${string.slice(start, end)}.`);
+}
+
+function skip(k) {
+  if (kind === k) {
+    lex();
+    return true;
+  }
+}
+
+function ch() {
+  if (end < strLen) {
+    end++;
+    code = end === strLen ? 0 : string.charCodeAt(end);
+  }
+}
+
+function lex() {
+  while (code === 9 || code === 10 || code === 13 || code === 32) {
+    ch();
+  }
+
+  if (code === 0) {
+    kind = 'EOF';
+    return;
+  }
+
+  start = end;
+
+  switch (code) {
+    // "
+    case 34:
+      kind = 'String';
+      return readString();
+    // -
+    case 45:
+    // 0-9
+    case 48: case 49: case 50: case 51: case 52:
+    case 53: case 54: case 55: case 56: case 57:
+      kind = 'Value';
+      return readNumber();
+    // f
+    case 102:
+      if (string.slice(start, start + 5) !== 'false') {
+        break;
+      }
+      end += 4; ch();
+
+      kind = 'Value';
+      return;
+    // n
+    case 110:
+      if (string.slice(start, start + 4) !== 'null') {
+        break;
+      }
+      end += 3; ch();
+
+      kind = 'Value';
+      return;
+    // t
+    case 116:
+      if (string.slice(start, start + 4) !== 'true') {
+        break;
+      }
+      end += 3; ch();
+
+      kind = 'Value';
+      return;
+  }
+
+  kind = string[start];
+  ch();
+}
+
+function readString() {
+  ch();
+  while (code !== 34) {
+    ch();
+    if (code === 92) { // \
+      ch();
+      switch (code) {
+        case 34: // '
+        case 47: // /
+        case 92: // \
+        case 98: // b
+        case 102: // f
+        case 110: // n
+        case 114: // r
+        case 116: // t
+          ch();
+          break;
+        case 117: // u
+          ch();
+          readHex();
+          readHex();
+          readHex();
+          readHex();
+          break;
+        default:
+          throw syntaxError('Bad character escape sequence.');
+      }
+    } else if (end === strLen) {
+      throw syntaxError('Unterminated string.');
+    }
+  }
+
+  if (code === 34) {
+    ch();
+    return;
+  }
+
+  throw syntaxError('Unterminated string.');
+}
+
+function readHex() {
+  if (
+    (code >= 48 && code <= 57) || // 0-9
+    (code >= 65 && code <= 70) || // A-F
+    (code >= 97 && code <= 102)   // a-f
+  ) {
+    return ch();
+  }
+  throw syntaxError('Expected hexadecimal digit.');
+}
+
+function readNumber() {
+  if (code === 45) { // -
+    ch();
+  }
+
+  if (code === 48) { // 0
+    ch();
+  } else {
+    readDigits();
+  }
+
+  if (code === 46) { // .
+    ch();
+    readDigits();
+  }
+
+  if (code === 69 || code === 101) { // E e
+    ch();
+    if (code === 43 || code === 45) { // + -
+      ch();
+    }
+    readDigits();
+  }
+}
+
+function readDigits() {
+  if (code < 48 || code > 57) { // 0 - 9
+    throw syntaxError('Expected decimal digit.');
+  }
+  do {
+    ch();
+  } while (code >= 48 && code <= 57); // 0 - 9
+}


### PR DESCRIPTION
Not sure if intended, but json-lint codemirror feature stayed behind. Moving this over will resolve `jsdom` dependency issue as well since we could eliminate the need for it after all. Creating a PR just in case.

Also, `babel-runtime` module was missing from package.json. Added that.