### PR TITLE
Add support for `subscription` operation

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "prepublish": "npm run build"
   },
   "peerDependencies": {
-    "graphql": "^0.4.7",
+    "graphql": "^0.4.8",
     "codemirror": "^5.6.0"
   },
   "devDependencies": {
@@ -58,7 +58,7 @@
     "codemirror": "5.6.0",
     "eslint": "1.2.1",
     "flow-bin": "0.16.0",
-    "graphql": "0.4.7",
+    "graphql": "0.4.8",
     "jsdom": "6.5.1",
     "mocha": "2.2.5",
     "sane": "1.3.0"

--- a/src/__tests__/hint-test.js
+++ b/src/__tests__/hint-test.js
@@ -71,7 +71,7 @@ describe('graphql-hint', () => {
 
   it('provides correct initial keywords', async () => {
     var suggestions = await getHintSuggestions('', { line: 0, ch: 0 });
-    var initialKeywords = [ 'query', 'mutation', 'fragment', '{' ];
+    var initialKeywords = [ 'query', 'mutation', 'subscription', 'fragment', '{' ];
     checkSuggestions(initialKeywords, suggestions.list);
   });
 

--- a/src/__tests__/kitchen-sink.graphql
+++ b/src/__tests__/kitchen-sink.graphql
@@ -36,6 +36,14 @@ mutation mutationName {
   setString(value: "newString")
 }
 
+subscription subscriptionName {
+  subscribeToTest(id: "anId") {
+    ... on Test {
+      id
+    }
+  }
+}
+
 fragment frag on Test {
   test @include(if: true) {
     union {

--- a/src/__tests__/mode-test.js
+++ b/src/__tests__/mode-test.js
@@ -73,6 +73,16 @@ describe('graphql-mode', () => {
     `, 'graphql', token => {
       expect(token).to.not.equal('invalidchar');
     });
+
+    CodeMirror.runMode(`
+      subscription {
+        subscribeToTest(id: "anId") {
+          id
+        }
+      }
+    `, 'graphql', token => {
+      expect(token).to.not.equal('invalidchar');
+    });
   });
 
 });

--- a/src/__tests__/testSchema.js
+++ b/src/__tests__/testSchema.js
@@ -142,7 +142,22 @@ var TestMutationType = new GraphQLObjectType({
   }
 });
 
+var TestSubscriptionType = new GraphQLObjectType({
+  name: 'SubscriptionType',
+  description: 'This is a simple subscription type',
+  fields: {
+    subscribeToTest: {
+      type: TestType,
+      description: 'Subscribe to the test type',
+      args: {
+        id: { type: GraphQLString }
+      }
+    }
+  }
+});
+
 export var TestSchema = new GraphQLSchema({
   query: TestType,
-  mutation: TestMutationType
+  mutation: TestMutationType,
+  subscription: TestSubscriptionType
 });

--- a/src/hint.js
+++ b/src/hint.js
@@ -66,6 +66,7 @@ CodeMirror.registerHelper('hint', 'graphql', (editor, options) => {
     return hintList(editor, options, cur, token, [
       { text: 'query' },
       { text: 'mutation' },
+      { text: 'subscription' },
       { text: 'fragment' },
       { text: '{' },
     ]);
@@ -188,7 +189,8 @@ CodeMirror.registerHelper('hint', 'graphql', (editor, options) => {
          state.prevState.kind === 'FragmentSpread')) ||
       (directive.onOperation &&
         (state.prevState.kind === 'Query' ||
-         state.prevState.kind === 'Mutation'))
+         state.prevState.kind === 'Mutation' ||
+         state.prevState.kind === 'Subscription' ))
     );
     return hintList(editor, options, cur, token, directives.map(directive => ({
       text: directive.name,
@@ -219,6 +221,9 @@ function getTypeInfo(schema, tokenState) {
         break;
       case 'Mutation':
         info.type = schema.getMutationType();
+        break;
+      case 'Subscription':
+        info.type = schema.getSubscriptionType();
         break;
       case 'InlineFragment':
       case 'FragmentDefinition':

--- a/src/mode.js
+++ b/src/mode.js
@@ -324,6 +324,7 @@ var ParseRules = {
     switch (token.value) {
       case 'query': return 'Query';
       case 'mutation': return 'Mutation';
+      case 'subscription': return 'Subscription';
       case 'fragment': return 'FragmentDefinition';
       case '{': return 'ShortQuery';
     }
@@ -340,6 +341,13 @@ var ParseRules = {
   Mutation: [
     word('mutation'),
     opt(name('def')),
+    opt('VariableDefinitions'),
+    list('Directive'),
+    'SelectionSet'
+  ],
+  Subscription: [
+    word('subscription'),
+    name('def'),
     opt('VariableDefinitions'),
     list('Directive'),
     'SelectionSet'


### PR DESCRIPTION
Adds support for `subscription` operation added to graphql-js in 0.4.8.