### PR TITLE
Support Relay-style optional fragment names

### DIFF
--- a/src/mode.js
+++ b/src/mode.js
@@ -275,10 +275,10 @@ function word(value) {
 }
 
 // A Name Token which will decorate the state with a `name`
-function name(style) {
+function name(style, fn = () => true) {
   return {
     style,
-    match: token => token.kind === 'Name',
+    match: token => token.kind === 'Name' && fn(token.value),
     update(state, token) {
       state.name = token.value;
     }
@@ -379,7 +379,7 @@ var ParseRules = {
   ],
   FragmentDefinition: [
     word('fragment'),
-    name('def'),
+    opt(name('def', value => value !== 'on')),
     'TypeCondition',
     list('Directive'),
     'SelectionSet'


### PR DESCRIPTION
Fixes #4.

@leebyron Let me know if there is a better way to do this. `opt(name('def'))` alone doesn't work, as it just swallows the `on` as the name and doesn't recover. This seems safe since the spec prohibits `on` as a name anyway.