### PR TITLE
make TypeCondition optional in InlineFragments

### DIFF
--- a/src/__tests__/mode-test.js
+++ b/src/__tests__/mode-test.js
@@ -36,6 +36,20 @@ describe('graphql-mode', () => {
     ]);
   });
 
+  it('parses inline fragments with optional syntax correctly', () => {
+    CodeMirror.runMode('{ ... on OptionalType { name } }', 'graphql',
+      (token, style) => expect(style).to.not.equal('invalidchar')
+    );
+
+    CodeMirror.runMode('{ ... { name } }', 'graphql',
+      (token, style) => expect(style).to.not.equal('invalidchar')
+    );
+
+    CodeMirror.runMode('{ ... @optionalDirective { name } }', 'graphql',
+      (token, style) => expect(style).to.not.equal('invalidchar')
+    );
+  });
+
   it('returns "invalidchar" message when there is no matching token', () => {
     CodeMirror.runMode('qauery name', 'graphql', (token, style) => {
       if (token.trim()) {

--- a/src/mode.js
+++ b/src/mode.js
@@ -359,8 +359,8 @@ var ParseRules = {
   SelectionSet: [ p('{'), list('Selection'), p('}') ],
   Selection(token, stream) {
     return token.value === '...' ?
-      stream.match(/[\s\u00a0,]*on\b/, false) ?
-        'InlineFragment' : 'FragmentSpread' :
+      stream.match(/[\s\u00a0,]*(?!on\b)[_A-Za-z][_0-9A-Za-z]*/, false) ?
+        'FragmentSpread' : 'InlineFragment' :
       stream.match(/[\s\u00a0,]*:/, false) ? 'AliasedField' : 'Field';
   },
   // Note: this minor deviation of "AliasedField" simplifies the lookahead.


### PR DESCRIPTION
Addresses #8. Instead of checking for `on` keyword (which is optional) to determine whether the rule is `InlineFragment` or `FragmentSpread`, do a negative lookahead for `on` keyword and match any words to determine `FragmentSpread`. This allows TypeCondition (`on {Type}`) to be optional in inline fragments.

There are false positives in tests that did not catch this - will address in the later PR.