### PR TITLE
provide a way to express exclusions/constraints described in spec

### DIFF
--- a/src/__tests__/mode-test.js
+++ b/src/__tests__/mode-test.js
@@ -36,6 +36,12 @@ describe('graphql-mode', () => {
     ]);
   });
 
+  it('parses Relay-style anonymous FragmentDefinitions', () => {
+    CodeMirror.runMode('fragment on Test { id }', 'graphql',
+      (token, style) => expect(style).to.not.equal('invalidchar')
+    );
+  });
+
   it('parses inline fragments with optional syntax correctly', () => {
     CodeMirror.runMode('{ ... on OptionalType { name } }', 'graphql',
       (token, style) => expect(style).to.not.equal('invalidchar')

--- a/src/mode.js
+++ b/src/mode.js
@@ -243,6 +243,15 @@ function lex(stream) {
   }
 }
 
+// An constraint described as `but not` in the GraphQL spec.
+function butNot(rule, exclusions) {
+  var ruleMatch = rule.match;
+  rule.match =
+    token => ruleMatch(token) &&
+    exclusions.every(exclusion => !exclusion.match(token));
+  return rule;
+}
+
 // An optional rule.
 function opt(ofRule) {
   return { ofRule };
@@ -379,7 +388,7 @@ var ParseRules = {
   ],
   FragmentDefinition: [
     word('fragment'),
-    name('def'),
+    opt(butNot(name('def'), [ word('on') ])),
     'TypeCondition',
     list('Directive'),
     'SelectionSet'


### PR DESCRIPTION
Tried to elaborate what I said in #5. Provide a method to support `but not` phrases from the specifications. Maybe an overkill since there's only several `but not`s and #5 works just well