### PR TITLE
Intellegent typeahead for fragment spread names

### DIFF
--- a/src/__tests__/hint-test.js
+++ b/src/__tests__/hint-test.js
@@ -137,4 +137,32 @@ describe('graphql-hint', () => {
     var testInputNames = Object.keys(TestSchema.getType('TestInput').getFields());
     checkSuggestions(testInputNames, suggestions.list);
   });
+
+  it('provides fragment name suggestion', async () => {
+    var suggestions = await getHintSuggestions(
+      'fragment Foo on Test { id }  query { ...',
+      { line: 0, ch: 40 }
+    );
+    checkSuggestions([ 'Foo' ], suggestions.list);
+  });
+
+  it('provides fragment names for fragments defined lower', async () => {
+    var suggestions = await getHintSuggestions(
+      'query { ... } fragment Foo on Test { id }',
+      { line: 0, ch: 11 }
+    );
+    checkSuggestions([ 'Foo' ], suggestions.list);
+  });
+
+  it('provides only appropriate fragment names', async () => {
+    var suggestions = await getHintSuggestions(
+      'fragment Foo on TestUnion { ... } ' +
+      'fragment Bar on First { name } ' +
+      'fragment Baz on Second { name } ' +
+      'fragment Qux on TestUnion { name } ' +
+      'fragment Nrf on Test { id }',
+      { line: 0, ch: 31 }
+    );
+    checkSuggestions([ 'Bar', 'Baz', 'Qux' ], suggestions.list);
+  });
 });

--- a/src/mode.js
+++ b/src/mode.js
@@ -368,8 +368,8 @@ var ParseRules = {
   SelectionSet: [ p('{'), list('Selection'), p('}') ],
   Selection(token, stream) {
     return token.value === '...' ?
-      stream.match(/[\s\u00a0,]*(?!on\b)[_A-Za-z]/, false) ?
-        'FragmentSpread' : 'InlineFragment' :
+      stream.match(/[\s\u00a0,]*(on\b|@|{)/, false) ?
+        'InlineFragment' : 'FragmentSpread' :
       stream.match(/[\s\u00a0,]*:/, false) ? 'AliasedField' : 'Field';
   },
   // Note: this minor deviation of "AliasedField" simplifies the lookahead.


### PR DESCRIPTION
As suggested by #7, this allows for a typeahead to appear after `...` including all relevant fragment names.

To fulfill this, I needed to make a minor alteration to the mode parser to not fork to the `InlineFragment` rule until some other signal characters are typed.