### PR TITLE
[RFC] Mode/hint/lint for GraphQL Variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ npm-debug.log
 node_modules/
 coverage/
 /*.js
+/utils
+/variables

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "hint.js",
     "mode.js",
     "lint.js",
+    "utils",
+    "variables",
     "README.md",
     "LICENSE"
   ],
@@ -33,7 +35,7 @@
     ]
   },
   "options": {
-    "mocha": "--full-trace --require resources/mocha-bootload src/**/*-test.js"
+    "mocha": "--full-trace --require resources/mocha-bootload src/**/__tests__/**/*-test.js"
   },
   "scripts": {
     "test": "npm run lint && npm run testonly",

--- a/src/hint.js
+++ b/src/hint.js
@@ -25,6 +25,9 @@ import {
   TypeMetaFieldDef,
   TypeNameMetaFieldDef,
 } from 'graphql/type/introspection';
+
+import forEachState from './utils/forEachState';
+import hintList from './utils/hintList';
 import './mode';
 
 
@@ -339,19 +342,6 @@ function getDefinitionState(tokenState) {
   return definitionState;
 }
 
-// Utility for iterating through a state stack bottom-up.
-function forEachState(stack, fn) {
-  var reverseStateStack = [];
-  var state = stack;
-  while (state && state.kind) {
-    reverseStateStack.push(state);
-    state = state.prevState;
-  }
-  for (var i = reverseStateStack.length - 1; i >= 0; i--) {
-    fn(reverseStateStack[i]);
-  }
-}
-
 // Finds all fragment definition ASTs in a source.
 function getFragmentDefinitions(editor) {
   const fragmentDefs = [];
@@ -405,114 +395,4 @@ function getFieldDef(schema, type, fieldName) {
   if (type.getFields) {
     return type.getFields()[fieldName];
   }
-}
-
-// Create the expected hint response given a possible list and a token
-function hintList(editor, options, cursor, token, list) {
-  var hints = filterAndSortList(list, normalizeText(token.string));
-  if (!hints) {
-    return;
-  }
-
-  var tokenStart = token.type !== null && /\w/.test(token.string[0]) ?
-    token.start :
-    token.end;
-
-  var results = {
-    list: hints,
-    from: CodeMirror.Pos(cursor.line, tokenStart),
-    to: CodeMirror.Pos(cursor.line, token.end),
-  };
-
-  CodeMirror.signal(editor, 'hasCompletion', editor, results, token);
-
-  return results;
-}
-
-// Given a list of hint entries and currently typed text, sort and filter to
-// provide a concise list.
-function filterAndSortList(list, text) {
-  var sorted = !text ? list : list.map(
-    entry => ({
-      proximity: getProximity(normalizeText(entry.text), text),
-      entry
-    })
-  ).filter(
-    pair => pair.proximity <= 2
-  ).sort(
-    (a, b) =>
-      (a.proximity - b.proximity) ||
-      (a.entry.text.length - b.entry.text.length)
-  ).map(
-    pair => pair.entry
-  );
-
-  return sorted.length > 0 ? sorted : list;
-}
-
-function normalizeText(text) {
-  return text.toLowerCase().replace(/\W/g, '');
-}
-
-// Determine a numeric proximity for a suggestion based on current text.
-function getProximity(suggestion, text) {
-  // start with lexical distance
-  var proximity = lexicalDistance(text, suggestion);
-  if (suggestion.length > text.length) {
-    // do not penalize long suggestions.
-    proximity -= suggestion.length - text.length - 1;
-    // penalize suggestions not starting with this phrase
-    proximity += suggestion.indexOf(text) === 0 ? 0 : 0.5;
-  }
-  return proximity;
-}
-
-/**
- * Computes the lexical distance between strings A and B.
- *
- * The "distance" between two strings is given by counting the minimum number
- * of edits needed to transform string A into string B. An edit can be an
- * insertion, deletion, or substitution of a single character, or a swap of two
- * adjacent characters.
- *
- * This distance can be useful for detecting typos in input or sorting
- *
- * @param {string} a
- * @param {string} b
- * @return {int} distance in number of edits
- */
-function lexicalDistance(a, b) {
-  var i;
-  var j;
-  var d = [];
-  var aLength = a.length;
-  var bLength = b.length;
-
-  for (i = 0; i <= aLength; i++) {
-    d[i] = [ i ];
-  }
-
-  for (j = 1; j <= bLength; j++) {
-    d[0][j] = j;
-  }
-
-  for (i = 1; i <= aLength; i++) {
-    for (j = 1; j <= bLength; j++) {
-      var cost = a[i - 1] === b[j - 1] ? 0 : 1;
-
-      d[i][j] = Math.min(
-        d[i - 1][j] + 1,
-        d[i][j - 1] + 1,
-        d[i - 1][j - 1] + cost
-      );
-
-      if (i > 1 && j > 1 &&
-          a[i - 1] === b[j - 2] &&
-          a[i - 2] === b[j - 1]) {
-        d[i][j] = Math.min(d[i][j], d[i - 2][j - 2] + cost);
-      }
-    }
-  }
-
-  return d[aLength][bLength];
 }

--- a/src/lint.js
+++ b/src/lint.js
@@ -23,7 +23,7 @@ import { parse, validate } from 'graphql';
  *   - schema: GraphQLSchema provides the linter with positionally relevant info
  *
  */
-CodeMirror.registerHelper('lint', 'graphql', function (text, options, editor) {
+CodeMirror.registerHelper('lint', 'graphql', (text, options, editor) => {
   var schema = options.schema;
   try {
     var ast = parse(text);

--- a/src/utils/collectVariables.js
+++ b/src/utils/collectVariables.js
@@ -1,0 +1,32 @@
+/**
+ *  Copyright (c) 2015, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+import { typeFromAST } from 'graphql';
+
+
+/**
+ * Provided a schema and a document, produces a `variableToType` Object.
+ */
+export default function collectVariables(schema, documentAST) {
+  const variableToType = Object.create(null);
+  documentAST.definitions.forEach(definition => {
+    if (definition.kind === 'OperationDefinition') {
+      const variableDefinitions = definition.variableDefinitions;
+      if (variableDefinitions) {
+        variableDefinitions.forEach(({ variable, type }) => {
+          const inputType = typeFromAST(schema, type);
+          if (inputType) {
+            variableToType[variable.name.value] = inputType;
+          }
+        });
+      }
+    }
+  });
+  return variableToType;
+}

--- a/src/utils/forEachState.js
+++ b/src/utils/forEachState.js
@@ -1,0 +1,21 @@
+/**
+ *  Copyright (c) 2015, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+// Utility for iterating through a CodeMirror parse state stack bottom-up.
+export default function forEachState(stack, fn) {
+  var reverseStateStack = [];
+  var state = stack;
+  while (state && state.kind) {
+    reverseStateStack.push(state);
+    state = state.prevState;
+  }
+  for (var i = reverseStateStack.length - 1; i >= 0; i--) {
+    fn(reverseStateStack[i]);
+  }
+}

--- a/src/utils/hintList.js
+++ b/src/utils/hintList.js
@@ -1,0 +1,121 @@
+/**
+ *  Copyright (c) 2015, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+import CodeMirror from 'codemirror';
+
+
+// Create the expected hint response given a possible list and a token
+export default function hintList(editor, options, cursor, token, list) {
+  const hints = filterAndSortList(list, normalizeText(token.string));
+  if (!hints) {
+    return;
+  }
+
+  const tokenStart = token.type !== null && /"|\w/.test(token.string[0]) ?
+    token.start :
+    token.end;
+
+  const results = {
+    list: hints,
+    from: CodeMirror.Pos(cursor.line, tokenStart),
+    to: CodeMirror.Pos(cursor.line, token.end),
+  };
+
+  CodeMirror.signal(editor, 'hasCompletion', editor, results, token);
+
+  return results;
+}
+
+// Given a list of hint entries and currently typed text, sort and filter to
+// provide a concise list.
+function filterAndSortList(list, text) {
+  const sorted = !text ? list : list.map(
+    entry => ({
+      proximity: getProximity(normalizeText(entry.text), text),
+      entry
+    })
+  ).filter(
+    pair => pair.proximity <= 2
+  ).sort(
+    (a, b) =>
+      (a.proximity - b.proximity) ||
+      (a.entry.text.length - b.entry.text.length)
+  ).map(
+    pair => pair.entry
+  );
+
+  return sorted.length > 0 ? sorted : list;
+}
+
+function normalizeText(text) {
+  return text.toLowerCase().replace(/\W/g, '');
+}
+
+// Determine a numeric proximity for a suggestion based on current text.
+function getProximity(suggestion, text) {
+  // start with lexical distance
+  let proximity = lexicalDistance(text, suggestion);
+  if (suggestion.length > text.length) {
+    // do not penalize long suggestions.
+    proximity -= suggestion.length - text.length - 1;
+    // penalize suggestions not starting with this phrase
+    proximity += suggestion.indexOf(text) === 0 ? 0 : 0.5;
+  }
+  return proximity;
+}
+
+/**
+ * Computes the lexical distance between strings A and B.
+ *
+ * The "distance" between two strings is given by counting the minimum number
+ * of edits needed to transform string A into string B. An edit can be an
+ * insertion, deletion, or substitution of a single character, or a swap of two
+ * adjacent characters.
+ *
+ * This distance can be useful for detecting typos in input or sorting
+ *
+ * @param {string} a
+ * @param {string} b
+ * @return {int} distance in number of edits
+ */
+function lexicalDistance(a, b) {
+  let i;
+  let j;
+  let d = [];
+  const aLength = a.length;
+  const bLength = b.length;
+
+  for (i = 0; i <= aLength; i++) {
+    d[i] = [ i ];
+  }
+
+  for (j = 1; j <= bLength; j++) {
+    d[0][j] = j;
+  }
+
+  for (i = 1; i <= aLength; i++) {
+    for (j = 1; j <= bLength; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+
+      d[i][j] = Math.min(
+        d[i - 1][j] + 1,
+        d[i][j - 1] + 1,
+        d[i - 1][j - 1] + cost
+      );
+
+      if (i > 1 && j > 1 &&
+          a[i - 1] === b[j - 2] &&
+          a[i - 2] === b[j - 1]) {
+        d[i][j] = Math.min(d[i][j], d[i - 2][j - 2] + cost);
+      }
+    }
+  }
+
+  return d[aLength][bLength];
+}

--- a/src/utils/jsonParse.js
+++ b/src/utils/jsonParse.js
@@ -1,0 +1,292 @@
+/**
+ *  Copyright (c) 2015, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+/**
+ * This JSON parser simply walks the input, generating an AST. Use this in lieu
+ * of JSON.parse if you need character offset parse errors and an AST parse tree
+ * with location information.
+ *
+ * If an error is encountered, a SyntaxError will be thrown, with properties:
+ *
+ *   - message: string
+ *   - start: int - the start inclusive offset of the syntax error
+ *   - end: int - the end exclusive offset of the syntax error
+ *
+ */
+export default function jsonParse(str) {
+  string = str;
+  strLen = str.length;
+  start = end = lastEnd = -1;
+  ch();
+  lex();
+  const ast = parseObj();
+  expect('EOF');
+  return ast;
+}
+
+let string;
+let strLen;
+let start;
+let end;
+let lastEnd;
+let code;
+let kind;
+
+function parseObj() {
+  const nodeStart = start;
+  const members = [];
+  expect('{');
+  if (!skip('}')) {
+    do {
+      members.push(parseMember());
+    } while (skip(','));
+    expect('}');
+  }
+  return {
+    kind: 'Object',
+    start: nodeStart,
+    end: lastEnd,
+    members
+  };
+}
+
+function parseMember() {
+  const nodeStart = start;
+  const key = kind === 'String' ? curToken() : null;
+  expect('String');
+  expect(':');
+  const value = parseVal();
+  return {
+    kind: 'Member',
+    start: nodeStart,
+    end: lastEnd,
+    key,
+    value
+  };
+}
+
+function parseArr() {
+  const nodeStart = start;
+  const values = [];
+  expect('[');
+  if (!skip(']')) {
+    do {
+      values.push(parseVal());
+    } while (skip(','));
+    expect(']');
+  }
+  return {
+    kind: 'Array',
+    start: nodeStart,
+    end: lastEnd,
+    values
+  };
+}
+
+function parseVal() {
+  switch (kind) {
+    case '[':
+      return parseArr();
+    case '{':
+      return parseObj();
+    case 'String':
+    case 'Number':
+    case 'Boolean':
+    case 'Null':
+      const token = curToken();
+      lex();
+      return token;
+  }
+  return expect('Value');
+}
+
+function curToken() {
+  return { kind, start, end, value: JSON.parse(string.slice(start, end)) };
+}
+
+function expect(str) {
+  if (kind === str) {
+    lex();
+    return;
+  }
+
+  let found;
+  if (kind === 'EOF') {
+    found = '[end of file]';
+  } else if (end - start > 1) {
+    found = '`' + string.slice(start, end) + '`';
+  } else {
+    const match = string.slice(start).match(/^.+?\b/);
+    found = '`' + (match ? match[0] : string[start]) + '`';
+  }
+
+  throw syntaxError(`Expected ${str} but found ${found}.`);
+}
+
+function syntaxError(message) {
+  return { message, start, end };
+}
+
+function skip(k) {
+  if (kind === k) {
+    lex();
+    return true;
+  }
+}
+
+function ch() {
+  if (end < strLen) {
+    end++;
+    code = end === strLen ? 0 : string.charCodeAt(end);
+  }
+}
+
+function lex() {
+  lastEnd = end;
+
+  while (code === 9 || code === 10 || code === 13 || code === 32) {
+    ch();
+  }
+
+  if (code === 0) {
+    kind = 'EOF';
+    return;
+  }
+
+  start = end;
+
+  switch (code) {
+    // "
+    case 34:
+      kind = 'String';
+      return readString();
+    // -
+    case 45:
+    // 0-9
+    case 48: case 49: case 50: case 51: case 52:
+    case 53: case 54: case 55: case 56: case 57:
+      kind = 'Number';
+      return readNumber();
+    // f
+    case 102:
+      if (string.slice(start, start + 5) !== 'false') {
+        break;
+      }
+      end += 4; ch();
+
+      kind = 'Boolean';
+      return;
+    // n
+    case 110:
+      if (string.slice(start, start + 4) !== 'null') {
+        break;
+      }
+      end += 3; ch();
+
+      kind = 'Null';
+      return;
+    // t
+    case 116:
+      if (string.slice(start, start + 4) !== 'true') {
+        break;
+      }
+      end += 3; ch();
+
+      kind = 'Boolean';
+      return;
+  }
+
+  kind = string[start];
+  ch();
+}
+
+function readString() {
+  ch();
+  while (code !== 34) {
+    ch();
+    if (code === 92) { // \
+      ch();
+      switch (code) {
+        case 34: // '
+        case 47: // /
+        case 92: // \
+        case 98: // b
+        case 102: // f
+        case 110: // n
+        case 114: // r
+        case 116: // t
+          ch();
+          break;
+        case 117: // u
+          ch();
+          readHex();
+          readHex();
+          readHex();
+          readHex();
+          break;
+        default:
+          throw syntaxError('Bad character escape sequence.');
+      }
+    } else if (end === strLen) {
+      throw syntaxError('Unterminated string.');
+    }
+  }
+
+  if (code === 34) {
+    ch();
+    return;
+  }
+
+  throw syntaxError('Unterminated string.');
+}
+
+function readHex() {
+  if (
+    (code >= 48 && code <= 57) || // 0-9
+    (code >= 65 && code <= 70) || // A-F
+    (code >= 97 && code <= 102)   // a-f
+  ) {
+    return ch();
+  }
+  throw syntaxError('Expected hexadecimal digit.');
+}
+
+function readNumber() {
+  if (code === 45) { // -
+    ch();
+  }
+
+  if (code === 48) { // 0
+    ch();
+  } else {
+    readDigits();
+  }
+
+  if (code === 46) { // .
+    ch();
+    readDigits();
+  }
+
+  if (code === 69 || code === 101) { // E e
+    ch();
+    if (code === 43 || code === 45) { // + -
+      ch();
+    }
+    readDigits();
+  }
+}
+
+function readDigits() {
+  if (code < 48 || code > 57) { // 0 - 9
+    throw syntaxError('Expected decimal digit.');
+  }
+  do {
+    ch();
+  } while (code >= 48 && code <= 57); // 0 - 9
+}

--- a/src/utils/onlineParser.js
+++ b/src/utils/onlineParser.js
@@ -1,0 +1,291 @@
+/**
+ *  Copyright (c) 2015, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+/**
+ * Builds an online immutable parser, designed to be used as part of a syntax
+ * highlighting and code intelligence tools.
+ *
+ * Options:
+ *
+ *     LexRules: { [name: string]: RegExp }, Includes `Punctuation`.
+ *
+ *     ParseRules: { [name: string]: Array<Rule> }, Includes `Document`.
+ *
+ *     eatWhitespace: (stream: CodeMirrorStream) => boolean, Use CodeMirror API.
+ *
+ */
+export default function onlineParser(options) {
+  const { eatWhitespace, LexRules, ParseRules } = options;
+  return {
+    startState() {
+      var initialState = { level: 0 };
+      pushRule(ParseRules, initialState, 'Document');
+      return initialState;
+    },
+    getToken(stream, state) {
+      return getToken(eatWhitespace, LexRules, ParseRules, this, stream, state);
+    }
+  };
+}
+
+// These functions help build matching rules for ParseRules.
+
+// An optional rule.
+export function opt(ofRule) {
+  return { ofRule };
+}
+
+// A list of another rule.
+export function list(ofRule, separator) {
+  return { ofRule, isList: true, separator };
+}
+
+// An constraint described as `but not` in the GraphQL spec.
+export function butNot(rule, exclusions) {
+  var ruleMatch = rule.match;
+  rule.match =
+    token => ruleMatch(token) &&
+    exclusions.every(exclusion => !exclusion.match(token));
+  return rule;
+}
+
+// Token of a kind
+export function t(kind, style) {
+  return { style, match: token => token.kind === kind };
+}
+
+// Punctuator
+export function p(value, style) {
+  return {
+    style: style || 'punctuation',
+    match: token => token.kind === 'Punctuation' && token.value === value
+  };
+}
+
+function getToken(eatWhitespace, LexRules, ParseRules, editor, stream, state) {
+  if (state.needsAdvance) {
+    state.needsAdvance = false;
+    advanceRule(state, true);
+  }
+
+  // Remember initial indentation
+  if (stream.sol()) {
+    state.indentLevel =
+      Math.floor(stream.indentation() / editor.config.tabSize);
+  }
+
+  // Consume spaces and ignored characters
+  if (eatWhitespace(stream)) {
+    return null;
+  }
+
+  // Tokenize line comment
+  if (editor.lineComment && stream.match(editor.lineComment)) {
+    stream.skipToEnd();
+    return 'comment';
+  }
+
+  // Lex a token from the stream
+  var token = lex(LexRules, stream);
+
+  // If there's no matching token, skip ahead.
+  if (!token) {
+    stream.match(/\S+/);
+    return 'invalidchar';
+  }
+
+  // Save state before continuing.
+  saveState(state);
+
+  // Handle changes in expected indentation level
+  if (token.kind === 'Punctuation') {
+    if (/^[{([]/.test(token.value)) {
+      // Push on the stack of levels one level deeper than the current level.
+      state.levels = (state.levels || []).concat(state.indentLevel + 1);
+    } else if (/^[})\]]/.test(token.value)) {
+      // Pop from the stack of levels.
+      // If the top of the stack is lower than the current level, lower the
+      // current level to match.
+      var levels = state.levels = (state.levels || []).slice(0, -1);
+      if (levels.length > 0 && levels[levels.length - 1] < state.indentLevel) {
+        state.indentLevel = levels[levels.length - 1];
+      }
+    }
+  }
+
+  while (state.rule) {
+    // If this is a forking rule, determine what rule to use based on
+    // the current token, otherwise expect based on the current step.
+    var expected =
+      typeof state.rule === 'function' ?
+        state.step === 0 ? state.rule(token, stream) : null :
+        state.rule[state.step];
+
+    // Seperator between list elements if necessary.
+    if (state.needsSeperator) {
+      expected = expected && expected.separator;
+    }
+
+    if (expected) {
+      // Un-wrap optional/list ParseRules.
+      if (expected.ofRule) {
+        expected = expected.ofRule;
+      }
+
+      // A string represents a Rule
+      if (typeof expected === 'string') {
+        pushRule(ParseRules, state, expected);
+        continue;
+      }
+
+      // Otherwise, match a Terminal.
+      if (expected.match && expected.match(token)) {
+        if (expected.update) {
+          expected.update(state, token);
+        }
+
+        // If this token was a punctuator, advance the parse rule, otherwise
+        // mark the state to be advanced before the next token. This ensures
+        // that tokens which can be appended to keep the appropriate state.
+        if (token.kind === 'Punctuation') {
+          advanceRule(state, true);
+        } else {
+          state.needsAdvance = true;
+        }
+
+        return expected.style;
+      }
+    }
+
+    unsuccessful(state);
+  }
+
+  // The parser does not know how to interpret this token, do not affect state.
+  restoreState(state);
+  return 'invalidchar';
+}
+
+function assign(to, from) {
+  var keys = Object.keys(from);
+  for (var i = 0; i < keys.length; i++) {
+    to[keys[i]] = from[keys[i]];
+  }
+  return to;
+}
+
+var stateCache = {};
+
+// Save the current state in the cache.
+function saveState(state) {
+  assign(stateCache, state);
+}
+
+// Restore from the state cache.
+function restoreState(state) {
+  assign(state, stateCache);
+}
+
+// Push a new rule onto the state.
+function pushRule(ParseRules, state, ruleKind) {
+  state.prevState = assign({}, state);
+  state.kind = ruleKind;
+  state.name = null;
+  state.type = null;
+  state.rule = ParseRules[ruleKind];
+  state.step = 0;
+  state.needsSeperator = false;
+}
+
+// Pop the current rule from the state.
+function popRule(state) {
+  state.kind = state.prevState.kind;
+  state.name = state.prevState.name;
+  state.type = state.prevState.type;
+  state.rule = state.prevState.rule;
+  state.step = state.prevState.step;
+  state.needsSeperator = state.prevState.needsSeperator;
+  state.prevState = state.prevState.prevState;
+}
+
+// Advance the step of the current rule.
+function advanceRule(state, successful) {
+  // If this is advancing successfully and the current state is a list, give
+  // it an opportunity to repeat itself.
+  if (isList(state)) {
+    if (state.rule[state.step].separator) {
+      state.needsSeperator = !state.needsSeperator;
+      // If the next list iteration might accept a non-separator, then give it
+      // an opportunity to repeat.
+      if (!state.needsSeperator) {
+        return;
+      }
+    }
+    // If this was a successful list parse, then allow it to repeat itself.
+    if (successful) {
+      return;
+    }
+  }
+
+  // Advance the step in the rule. If the rule is completed, pop
+  // the rule and advance the parent rule as well (recursively).
+  state.needsSeperator = false;
+  state.step++;
+  // While the current rule is completed.
+  while (
+    state.rule &&
+    !(Array.isArray(state.rule) && state.step < state.rule.length)
+  ) {
+    popRule(state);
+
+    if (state.rule) {
+      // Do not advance a List step so it has the opportunity to repeat itself.
+      if (isList(state)) {
+        if (state.rule[state.step].separator) {
+          state.needsSeperator = !state.needsSeperator;
+        }
+      } else {
+        state.needsSeperator = false;
+        state.step++;
+      }
+    }
+  }
+}
+
+function isList(state) {
+  return Array.isArray(state.rule) && state.rule[state.step].isList;
+}
+
+// Unwind the state after an unsuccessful match.
+function unsuccessful(state) {
+  // Fall back to the parent rule until you get to an optional or list rule or
+  // until the entire stack of rules is empty.
+  while (
+    state.rule &&
+    !(Array.isArray(state.rule) && state.rule[state.step].ofRule)
+  ) {
+    popRule(state);
+  }
+
+  // If there is still a rule, it must be an optional or list rule.
+  // Consider this rule a success so that we may move past it.
+  if (state.rule) {
+    advanceRule(state, false);
+  }
+}
+
+// Given a stream, returns a { kind, value } pair, or null.
+function lex(LexRules, stream) {
+  var kinds = Object.keys(LexRules);
+  for (var i = 0; i < kinds.length; i++) {
+    var match = stream.match(LexRules[kinds[i]]);
+    if (match) {
+      return { kind: kinds[i], value: match[0] };
+    }
+  }
+}

--- a/src/variables/__tests__/hint-test.js
+++ b/src/variables/__tests__/hint-test.js
@@ -1,0 +1,166 @@
+/* eslint-disable max-len */
+/**
+ *  Copyright (c) 2015, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import CodeMirror from 'codemirror';
+import 'codemirror/addon/hint/show-hint';
+import { parse } from 'graphql';
+
+import '../hint';
+import collectVariables from '../../utils/collectVariables';
+import { TestSchema } from '../../__tests__/testSchema';
+
+
+function createEditorWithHint(query) {
+  return CodeMirror(document.createElement('div'), {
+    mode: 'graphql-variables',
+    hintOptions: {
+      variableToType: query && collectVariables(TestSchema, parse(query)),
+      closeOnUnfocus: false,
+      completeSingle: false
+    }
+  });
+}
+
+function getHintSuggestions(query, variables, cursor) {
+  const editor = createEditorWithHint(query);
+  return new Promise(resolve => {
+    const graphqlVariablesHint = CodeMirror.hint['graphql-variables'];
+    CodeMirror.hint['graphql-variables'] = (cm, options) => {
+      const result = graphqlVariablesHint(cm, options);
+      resolve(result);
+      CodeMirror.hint['graphql-variables'] = graphqlVariablesHint;
+      return result;
+    };
+
+    editor.doc.setValue(variables);
+    editor.doc.setCursor(cursor);
+    editor.execCommand('autocomplete');
+  });
+}
+
+function checkSuggestions(source, suggestions) {
+  const titles = suggestions.map(suggestion => suggestion.text);
+  expect(titles).to.deep.equal(source);
+}
+
+describe('graphql-variables-hint', () => {
+  it('attaches a GraphQL hint function with correct mode/hint options', async () => {
+    const editor = await createEditorWithHint('{ f }');
+    expect(
+      editor.getHelpers(editor.getCursor(), 'hint')
+    ).to.not.have.lengthOf(0);
+  });
+
+  it('provides correct initial token', async () => {
+    const suggestions = await getHintSuggestions('', '', { line: 0, ch: 0 });
+    const initialKeywords = [ '{' ];
+    checkSuggestions(initialKeywords, suggestions.list);
+  });
+
+  it('provides correct field name suggestions', async () => {
+    const suggestions = await getHintSuggestions(
+      'query ($foo: String!, $bar: Int) { f }',
+      '{ ',
+      { line: 0, ch: 2 }
+    );
+    checkSuggestions([ '"foo": ', '"bar": ' ], suggestions.list);
+  });
+
+  it('provides correct variable suggestion indentation', async () => {
+    const suggestions = await getHintSuggestions(
+      'query ($foo: String!, $bar: Int) { f }',
+      '{\n  ',
+      { line: 1, ch: 2 }
+    );
+    expect(suggestions.from).to.deep.equal({ line: 1, ch: 2 });
+    expect(suggestions.to).to.deep.equal({ line: 1, ch: 2 });
+  });
+
+  it('provides correct variable completion', async () => {
+    const suggestions = await getHintSuggestions(
+      'query ($foo: String!, $bar: Int) { f }',
+      '{\n  ba',
+      { line: 1, ch: 4 }
+    );
+    checkSuggestions([ '"bar": ' ], suggestions.list);
+    expect(suggestions.from).to.deep.equal({ line: 1, ch: 2 });
+    expect(suggestions.to).to.deep.equal({ line: 1, ch: 4 });
+  });
+
+  it('provides correct variable completion with open quote', async () => {
+    const suggestions = await getHintSuggestions(
+      'query ($foo: String!, $bar: Int) { f }',
+      '{\n  "',
+      { line: 1, ch: 4 }
+    );
+    checkSuggestions([ '"foo": ', '"bar": ' ], suggestions.list);
+    expect(suggestions.from).to.deep.equal({ line: 1, ch: 2 });
+    expect(suggestions.to).to.deep.equal({ line: 1, ch: 3 });
+  });
+
+  it('provides correct Enum suggestions', async () => {
+    const suggestions = await getHintSuggestions(
+      'query ($myEnum: TestEnum) { f }',
+      '{\n  "myEnum": ',
+      { line: 1, ch: 12 }
+    );
+    const TestEnum = TestSchema.getType('TestEnum');
+    checkSuggestions(
+      TestEnum.getValues().map(value => `"${value.name}"`),
+      suggestions.list
+    );
+  });
+
+  it('suggests to open an Input Object', async () => {
+    const suggestions = await getHintSuggestions(
+      'query ($myInput: TestInput) { f }',
+      '{\n  "myInput": ',
+      { line: 1, ch: 13 }
+    );
+    checkSuggestions([ '{' ], suggestions.list);
+  });
+
+  it('provides Input Object fields', async () => {
+    const suggestions = await getHintSuggestions(
+      'query ($myInput: TestInput) { f }',
+      '{\n  "myInput": {\n    ',
+      { line: 2, ch: 4 }
+    );
+    const TestInput = TestSchema.getType('TestInput');
+    checkSuggestions(
+      Object.keys(TestInput.getFields()).map(name => `"${name}": `),
+      suggestions.list
+    );
+    expect(suggestions.from).to.deep.equal({ line: 2, ch: 4 });
+    expect(suggestions.to).to.deep.equal({ line: 2, ch: 4 });
+  });
+
+  it('provides correct Input Object field completion', async () => {
+    const suggestions = await getHintSuggestions(
+      'query ($myInput: TestInput) { f }',
+      '{\n  "myInput": {\n    bool',
+      { line: 2, ch: 8 }
+    );
+    checkSuggestions([ '"boolean": ', '"listBoolean": ' ], suggestions.list);
+    expect(suggestions.from).to.deep.equal({ line: 2, ch: 4 });
+    expect(suggestions.to).to.deep.equal({ line: 2, ch: 8 });
+  });
+
+  it('provides correct Input Object field value completion', async () => {
+    const suggestions = await getHintSuggestions(
+      'query ($myInput: TestInput) { f }',
+      '{\n  "myInput": {\n    "boolean": ',
+      { line: 2, ch: 15 }
+    );
+    checkSuggestions([ 'true', 'false' ], suggestions.list);
+  });
+});

--- a/src/variables/__tests__/lint-test.js
+++ b/src/variables/__tests__/lint-test.js
@@ -1,0 +1,102 @@
+/* eslint-disable max-len */
+/**
+ *  Copyright (c) 2015, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import CodeMirror from 'codemirror';
+import 'codemirror/addon/lint/lint';
+import { parse } from 'graphql';
+
+import '../lint';
+import collectVariables from '../../utils/collectVariables';
+import { TestSchema } from '../../__tests__/testSchema';
+
+
+function createEditorWithLint(lintConfig) {
+  return CodeMirror(document.createElement('div'), {
+    mode: 'graphql-variables',
+    lint: lintConfig ? lintConfig : true
+  });
+}
+
+function printLintErrors(query, variables) {
+  const editor = createEditorWithLint({
+    variableToType: query && collectVariables(TestSchema, parse(query)),
+  });
+
+  return new Promise((resolve, reject) => {
+    editor.state.lint.options.onUpdateLinting = (errors) => {
+      if (errors && errors[0]) {
+        if (!errors[0].message.match('Unexpected EOF')) {
+          resolve(errors);
+        }
+      }
+      reject();
+    };
+    editor.doc.setValue(variables);
+  }).then((errors) => {
+    return errors;
+  }).catch(() => {
+    return [];
+  });
+}
+
+describe('graphql-variables-lint', () => {
+  it('attaches a GraphQL lint function with correct mode/lint options', () => {
+    var editor = createEditorWithLint();
+    expect(
+      editor.getHelpers(editor.getCursor(), 'lint')
+    ).to.not.have.lengthOf(0);
+  });
+
+  it('catches syntax errors', async () => {
+    expect(
+      (await printLintErrors(null, '{ foo: "bar" }'))[0].message
+    ).to.equal('Expected String but found `foo`.');
+  });
+
+  it('catches type validation errors', async () => {
+    const errors = await printLintErrors(
+      'query ($foo: Int) { f }',
+      ' { "foo": "NaN" }'
+    );
+
+    expect(errors[0]).to.deep.equal({
+      message: 'Expected value of type "Int".',
+      severity: 'error',
+      type: 'validation',
+      from: { line: 0, ch: 10 },
+      to: { line: 0, ch: 15 }
+    });
+  });
+
+  it('reports unknown variable names', async () => {
+    const errors = await printLintErrors(
+      'query ($foo: Int) { f }',
+      ' { "food": "NaN" }'
+    );
+
+    expect(errors[0]).to.deep.equal({
+      message: 'Variable "$food" does not appear in any GraphQL query.',
+      severity: 'error',
+      type: 'validation',
+      from: { line: 0, ch: 3 },
+      to: { line: 0, ch: 9 }
+    });
+  });
+
+  it('reports nothing when not configured', async () => {
+    const errors = await printLintErrors(
+      null,
+      ' { "foo": "NaN" }'
+    );
+    expect(errors.length).to.equal(0);
+  });
+});

--- a/src/variables/__tests__/mode-test.js
+++ b/src/variables/__tests__/mode-test.js
@@ -1,0 +1,99 @@
+/**
+ *  Copyright (c) 2015, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import CodeMirror from 'codemirror';
+import 'codemirror/addon/runmode/runmode';
+
+import '../mode';
+
+
+describe('graphql-variables-mode', () => {
+
+  it('provides correct tokens and styles after parsing', () => {
+    const queryStr =
+      '{ "variable": { "field": "value" }, "list": [ 1, true, null ] }';
+    const tokens = [];
+
+    CodeMirror.runMode(queryStr, 'graphql-variables', (token, style) => {
+      if (style) {
+        tokens.push([ token, style ]);
+      }
+    });
+
+    expect(tokens).to.deep.equal([
+      [ '{', 'punctuation' ],
+      [ '"variable"', 'variable' ],
+      [ ':', 'punctuation' ],
+      [ '{', 'punctuation' ],
+      [ '"field"', 'attribute' ],
+      [ ':', 'punctuation' ],
+      [ '"value"', 'string' ],
+      [ '}', 'punctuation' ],
+      [ ',', 'punctuation' ],
+      [ '"list"', 'variable' ],
+      [ ':', 'punctuation' ],
+      [ '[', 'punctuation' ],
+      [ '1', 'number' ],
+      [ ',', 'punctuation' ],
+      [ 'true', 'builtin' ],
+      [ ',', 'punctuation' ],
+      [ 'null', 'keyword' ],
+      [ ']', 'punctuation' ],
+      [ '}', 'punctuation' ]
+    ]);
+  });
+
+  it('is resilient to missing commas', () => {
+    const queryStr =
+      '{ "variable": { "field": "value" } "list": [ 1 true null ] }';
+    const tokens = [];
+
+    CodeMirror.runMode(queryStr, 'graphql-variables', (token, style) => {
+      if (style) {
+        tokens.push([ token, style ]);
+      }
+    });
+
+    expect(tokens).to.deep.equal([
+      [ '{', 'punctuation' ],
+      [ '"variable"', 'variable' ],
+      [ ':', 'punctuation' ],
+      [ '{', 'punctuation' ],
+      [ '"field"', 'attribute' ],
+      [ ':', 'punctuation' ],
+      [ '"value"', 'string' ],
+      [ '}', 'punctuation' ],
+      [ '"list"', 'variable' ],
+      [ ':', 'punctuation' ],
+      [ '[', 'punctuation' ],
+      [ '1', 'number' ],
+      [ 'true', 'builtin' ],
+      [ 'null', 'keyword' ],
+      [ ']', 'punctuation' ],
+      [ '}', 'punctuation' ]
+    ]);
+  });
+
+  it('returns "invalidchar" message when there is no matching token', () => {
+    CodeMirror.runMode('herp derp', 'graphql-variables', (token, style) => {
+      if (token.trim()) {
+        expect(style).to.equal('invalidchar');
+      }
+    });
+
+    CodeMirror.runMode('{ foo', 'graphql-variables', (token, style) => {
+      if (token === 'foo') {
+        expect(style).to.equal('invalidchar');
+      }
+    });
+  });
+
+});

--- a/src/variables/hint.js
+++ b/src/variables/hint.js
@@ -1,0 +1,148 @@
+/**
+ *  Copyright (c) 2015, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+import CodeMirror from 'codemirror';
+import {
+  getNullableType,
+  getNamedType,
+  GraphQLEnumType,
+  GraphQLInputObjectType,
+  GraphQLList,
+  GraphQLBoolean,
+} from 'graphql';
+
+import forEachState from '../utils/forEachState';
+import hintList from '../utils/hintList';
+import './mode';
+
+
+/**
+ * Registers a "hint" helper for CodeMirror.
+ *
+ * Using CodeMirror's "hint" addon: https://codemirror.net/demo/complete.html
+ * Given an editor, this helper will take the token at the cursor and return a
+ * list of suggested tokens.
+ *
+ * Options:
+ *
+ *   - variableToType: { [variable: string]: GraphQLInputType }
+ *
+ * Additional Events:
+ *
+ *   - hasCompletion (codemirror, data, token) - signaled when the hinter has a
+ *     new list of completion suggestions.
+ *
+ */
+CodeMirror.registerHelper('hint', 'graphql-variables', (editor, options) => {
+  const cur = editor.getCursor();
+  const token = editor.getTokenAt(cur);
+  const state = token.state;
+  const kind = state.kind;
+  const step = state.step;
+
+  // Variables can only be an object literal.
+  if (kind === 'Document' && step === 0) {
+    return hintList(editor, options, cur, token, [
+      { text: '{' },
+    ]);
+  }
+
+  const variableToType = options.variableToType;
+  if (!variableToType) {
+    return;
+  }
+
+  const typeInfo = getTypeInfo(variableToType, token.state);
+
+  // Top level should typeahead possible variables.
+  if (kind === 'Document' || kind === 'Variable' && step === 0) {
+    const variableNames = Object.keys(variableToType);
+    return hintList(editor, options, cur, token, variableNames.map(name => ({
+      text: `"${name}": `,
+      type: variableToType[name]
+    })));
+  }
+
+  // Input Object fields
+  if (kind === 'ObjectValue' || kind === 'ObjectField' && step === 0) {
+    if (typeInfo.fields) {
+      const inputFields = Object.keys(typeInfo.fields)
+        .map(fieldName => typeInfo.fields[fieldName]);
+      return hintList(editor, options, cur, token, inputFields.map(field => ({
+        text: `"${field.name}": `,
+        type: field.type,
+        description: field.description
+      })));
+    }
+  }
+
+  // Input values.
+  if (
+    kind === 'StringValue' ||
+    kind === 'NumberValue' ||
+    kind === 'BooleanValue' ||
+    kind === 'NullValue' ||
+    kind === 'ListValue' && step === 1 ||
+    kind === 'ObjectField' && step === 2 ||
+    kind === 'Variable' && step === 2
+  ) {
+    const namedInputType = getNamedType(typeInfo.type);
+    if (namedInputType instanceof GraphQLInputObjectType) {
+      return hintList(editor, options, cur, token, [
+        { text: '{' },
+      ]);
+    } else if (namedInputType instanceof GraphQLEnumType) {
+      const valueMap = namedInputType.getValues();
+      const values = Object.keys(valueMap).map(name => valueMap[name]);
+      return hintList(editor, options, cur, token, values.map(value => ({
+        text: `"${value.name}"`,
+        type: namedInputType,
+        description: value.description
+      })));
+    } else if (namedInputType === GraphQLBoolean) {
+      return hintList(editor, options, cur, token, [
+        { text: 'true', type: GraphQLBoolean, description: 'Not false.' },
+        { text: 'false', type: GraphQLBoolean, description: 'Not true.' },
+      ]);
+    }
+  }
+});
+
+
+// Utility for collecting rich type information given any token's state
+// from the graphql-variables-mode parser.
+function getTypeInfo(variableToType, tokenState) {
+  const info = {
+    type: null,
+    fields: null,
+  };
+
+  forEachState(tokenState, state => {
+    if (state.kind === 'Variable') {
+      info.type = variableToType[state.name];
+    } else if (state.kind === 'ListValue') {
+      const nullableType = getNullableType(info.type);
+      info.type = nullableType instanceof GraphQLList ?
+        nullableType.ofType :
+        null;
+    } else if (state.kind === 'ObjectValue') {
+      const objectType = getNamedType(info.type);
+      info.fields = objectType instanceof GraphQLInputObjectType ?
+        objectType.getFields() :
+        null;
+    } else if (state.kind === 'ObjectField') {
+      const objectField = state.name && info.fields ?
+        info.fields[state.name] :
+        null;
+      info.type = objectField && objectField.type;
+    }
+  });
+
+  return info;
+}

--- a/src/variables/lint.js
+++ b/src/variables/lint.js
@@ -1,0 +1,195 @@
+/* eslint-disable max-len */
+/**
+ *  Copyright (c) 2015, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+import CodeMirror from 'codemirror';
+import {
+  GraphQLEnumType,
+  GraphQLInputObjectType,
+  GraphQLList,
+  GraphQLNonNull,
+  GraphQLScalarType,
+} from 'graphql';
+
+import jsonParse from '../utils/jsonParse';
+
+
+/**
+ * Registers a "lint" helper for CodeMirror.
+ *
+ * Using CodeMirror's "lint" addon: https://codemirror.net/demo/lint.html
+ * Given the text within an editor, this helper will take that text and return
+ * a list of linter issues ensuring that correct variables were provided.
+ *
+ * Options:
+ *
+ *   - variableToType: { [variable: string]: GraphQLInputType }
+ *
+ */
+CodeMirror.registerHelper('lint', 'graphql-variables', (text, options, editor) => {
+  // If there's no text, do nothing.
+  if (!text) {
+    return [];
+  }
+
+  // First, linter needs to determine if there are any parsing errors.
+  let ast;
+  try {
+    ast = jsonParse(text);
+  } catch (syntaxError) {
+    if (syntaxError.stack) {
+      throw syntaxError;
+    }
+    return [ lintError(editor, syntaxError, syntaxError.message) ];
+  }
+
+  // If there are not yet known variables, do nothing.
+  const variableToType = options.variableToType;
+  if (!variableToType) {
+    return [];
+  }
+
+  // Then highlight any issues with the provided variables.
+  return validateVariables(editor, variableToType, ast);
+});
+
+// Given a variableToType object, a source text, and a JSON AST, produces a
+// list of CodeMirror annotations for any variable validation errors.
+function validateVariables(editor, variableToType, variablesAST) {
+  const errors = [];
+
+  variablesAST.members.forEach(member => {
+    const variableName = member.key.value;
+    const type = variableToType[variableName];
+    if (!type) {
+      errors.push(lintError(editor, member.key,
+        `Variable "$${variableName}" does not appear in any GraphQL query.`
+      ));
+    } else {
+      validateValue(type, member.value).forEach(([ node, message ]) => {
+        errors.push(lintError(editor, node, message));
+      });
+    }
+  });
+
+  return errors;
+}
+
+// Returns a list of validation errors in the form Array<[Node, String]>.
+function validateValue(type, valueAST) {
+  // Validate non-nullable values.
+  if (type instanceof GraphQLNonNull) {
+    if (valueAST.kind === 'Null') {
+      return [[
+        valueAST,
+        `Type "${type}" is non-nullable and cannot be null.`
+      ]];
+    }
+    return validateValue(type.ofType, valueAST);
+  }
+
+  if (valueAST.kind === 'Null') {
+    return [];
+  }
+
+  // Validate lists of values, accepting a non-list as a list of one.
+  if (type instanceof GraphQLList) {
+    const itemType = type.ofType;
+    if (valueAST.kind === 'Array') {
+      return mapCat(valueAST.values, item => validateValue(itemType, item));
+    }
+    return validateValue(itemType, valueAST);
+  }
+
+  // Validate input objects.
+  if (type instanceof GraphQLInputObjectType) {
+    if (valueAST.kind !== 'Object') {
+      return [[ valueAST, `Type "${type}" must be an Object.` ]];
+    }
+
+    // Validate each field in the input object.
+    const providedFields = Object.create(null);
+    const fieldErrors = mapCat(valueAST.members, member => {
+      const fieldName = member.key.value;
+      providedFields[fieldName] = true;
+      const inputField = type.getFields()[fieldName];
+      if (!inputField) {
+        return [[
+          member.key,
+          `Type "${type}" does not have a field "${fieldName}".`
+        ]];
+      }
+      const fieldType = inputField ? inputField.type : undefined;
+      return validateValue(fieldType, member.value);
+    });
+
+    // Look for missing non-nullable fields.
+    Object.keys(type.getFields()).forEach(fieldName => {
+      if (!providedFields[fieldName]) {
+        const fieldType = type.getFields()[fieldName].type;
+        if (fieldType instanceof GraphQLNonNull) {
+          fieldErrors.push([
+            valueAST,
+            `Object of type "${type}" is missing required field "${fieldName}".`
+          ]);
+        }
+      }
+    });
+
+    return fieldErrors;
+  }
+
+  // Validate common scalars.
+  if (
+    type.name === 'Boolean' && valueAST.kind !== 'Boolean' ||
+    type.name === 'String' && valueAST.kind !== 'String' ||
+    type.name === 'ID' &&
+      valueAST.kind !== 'Number' && valueAST.kind !== 'String' ||
+    type.name === 'Float' && valueAST.kind !== 'Number' ||
+    type.name === 'Int' &&
+      (valueAST.kind !== 'Number' || (valueAST.value | 0) !== valueAST.value)
+  ) {
+    return [[ valueAST, `Expected value of type "${type}".` ]];
+  }
+
+  // Validate enums and custom scalars.
+  if (type instanceof GraphQLEnumType || type instanceof GraphQLScalarType) {
+    if (
+      (valueAST.kind !== 'String' &&
+       valueAST.kind !== 'Number' &&
+       valueAST.kind !== 'Boolean' &&
+       valueAST.kind !== 'Null') ||
+      isNullish(type.parseValue(valueAST.value))
+    ) {
+      return [[ valueAST, `Expected value of type "${type}".` ]];
+    }
+  }
+
+  return [];
+}
+
+// Give a parent text, an AST node with location, and a message, produces a
+// CodeMirror annotation object.
+function lintError(editor, node, message) {
+  return {
+    message,
+    severity: 'error',
+    type: 'validation',
+    from: editor.posFromIndex(node.start),
+    to: editor.posFromIndex(node.end),
+  };
+}
+
+function isNullish(value: mixed): boolean {
+  return value === null || value === undefined || value !== value;
+}
+
+function mapCat<T>(array: Array<T>, mapper: (item: T) => Array<T>): Array<T> {
+  return Array.prototype.concat.apply([], array.map(mapper));
+}

--- a/src/variables/mode.js
+++ b/src/variables/mode.js
@@ -1,0 +1,108 @@
+/**
+ *  Copyright (c) 2015, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+import CodeMirror from 'codemirror';
+
+import onlineParser, { list, t, p } from '../utils/onlineParser';
+
+
+/**
+ * This mode defines JSON, but provides a data-laden parser state to enable
+ * better code intelligence.
+ */
+CodeMirror.defineMode('graphql-variables', config => {
+  const parser = onlineParser({
+    eatWhitespace: stream => stream.eatSpace(),
+    LexRules,
+    ParseRules
+  });
+
+  return {
+    config,
+    startState: parser.startState,
+    token: parser.getToken,
+    indent,
+    electricInput: /^\s*[}\]]/,
+    fold: 'brace',
+    closeBrackets: {
+      pairs: '[]{}""',
+      explode: '[]{}'
+    },
+  };
+});
+
+function indent(state, textAfter) {
+  const levels = state.levels;
+  // If there is no stack of levels, use the current level.
+  // Otherwise, use the top level, pre-emptively dedenting for close braces.
+  const level = !levels || levels.length === 0 ? state.indentLevel :
+    levels[levels.length - 1] - (this.electricInput.test(textAfter) ? 1 : 0);
+  return level * this.config.indentUnit;
+}
+
+/**
+ * The lexer rules. These are exactly as described by the spec.
+ */
+const LexRules = {
+  // All Punctuation used in JSON.
+  Punctuation: /^\[|\]|\{|\}|\:|\,/,
+
+  // JSON Number.
+  Number: /^-?(?:0|(?:[1-9][0-9]*))(?:\.[0-9]*)?(?:[eE][+-]?[0-9]+)?/,
+
+  // JSON String.
+  String: /^"(?:[^"\\]|\\(?:b|f|n|r|t|u[0-9a-fA-F]{4}))*"?/,
+
+  // JSON literal keywords.
+  Keyword: /^true|false|null/,
+};
+
+/**
+ * The parser rules for JSON.
+ */
+const ParseRules = {
+  Document: [ p('{'), list('Variable', p(',')), p('}') ],
+  Variable: [ namedKey('variable'), p(':'), 'Value' ],
+  Value(token) {
+    switch (token.kind) {
+      case 'Number': return 'NumberValue';
+      case 'String': return 'StringValue';
+      case 'Punctuation':
+        switch (token.value) {
+          case '[': return 'ListValue';
+          case '{': return 'ObjectValue';
+        }
+        return null;
+      case 'Keyword':
+        switch (token.value) {
+          case 'true': case 'false': return 'BooleanValue';
+          case 'null': return 'NullValue';
+        }
+        return null;
+    }
+  },
+  NumberValue: [ t('Number', 'number') ],
+  StringValue: [ t('String', 'string') ],
+  BooleanValue: [ t('Keyword', 'builtin') ],
+  NullValue: [ t('Keyword', 'keyword') ],
+  ListValue: [ p('['), list('Value', p(',')), p(']') ],
+  ObjectValue: [ p('{'), list('ObjectField', p(',')), p('}') ],
+  ObjectField: [ namedKey('attribute'), p(':'), 'Value' ],
+};
+
+// A namedKey Token which will decorate the state with a `name`
+function namedKey(style) {
+  return {
+    style,
+    match: token => token.kind === 'String',
+    update(state, token) {
+      state.name = token.value.slice(1, -1); // Remove quotes.
+    }
+  };
+}


### PR DESCRIPTION
This provides a mode, hint, and lint helpers for JSON-formatted GraphQL variables. This improves syntax highlighting, provides smart typeaheads, and lints errors with red-underlines.