### PR TITLE
Typeahead possible overlapping interface types in type conditions

### DIFF
--- a/src/__tests__/hint-test.js
+++ b/src/__tests__/hint-test.js
@@ -98,7 +98,8 @@ describe('graphql-hint', () => {
       '{ union { ... on ', { line: 0, ch: 17 });
     var unionType = TestSchema.getQueryType().getFields().union.type;
     var typeConditionNames =
-      TestSchema.getPossibleTypes(unionType).map(type => type.name);
+      TestSchema.getPossibleTypes(unionType).map(type => type.name)
+        .concat([ 'TestInterface' ]);
     checkSuggestions(typeConditionNames, suggestions.list);
   });
 

--- a/src/__tests__/testSchema.js
+++ b/src/__tests__/testSchema.js
@@ -11,6 +11,7 @@ import {
   GraphQLSchema,
   GraphQLObjectType,
   GraphQLUnionType,
+  GraphQLInterfaceType,
   GraphQLEnumType,
   GraphQLInputObjectType,
   GraphQLBoolean,
@@ -53,9 +54,25 @@ var TestInputObject = new GraphQLInputObjectType({
   })
 });
 
+var TestInterface = new GraphQLInterfaceType({
+  name: 'TestInterface',
+  resolveType: () => UnionFirst,
+  fields: {
+    scalar: {
+      type: GraphQLString,
+      resolve: () => ({})
+    }
+  }
+});
+
 var UnionFirst = new GraphQLObjectType({
   name: 'First',
+  interfaces: [ TestInterface ],
   fields: () => ({
+    scalar: {
+      type: GraphQLString,
+      resolve: () => ({})
+    },
     first: {
       type: TestType,
       resolve: () => ({})

--- a/src/utils/objectValues.js
+++ b/src/utils/objectValues.js
@@ -1,0 +1,18 @@
+/**
+ *  Copyright (c) 2015, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+export default function objectValues(object) {
+  const keys = Object.keys(object);
+  const len = keys.length;
+  const values = new Array(len);
+  for (let i = 0; i < len; ++i) {
+    values[i] = object[keys[i]];
+  }
+  return values;
+}


### PR DESCRIPTION
This adds valid interfaces to the set of types in the typeahead when completing type conditions for fragments.

Suggested by https://github.com/graphql/graphiql/issues/119

Also applies the objectValues pattern throughout