### PR TITLE
[RFC] Introduce GraphQLStream

### DIFF
--- a/src/mode.js
+++ b/src/mode.js
@@ -8,7 +8,8 @@
  */
 
 import CodeMirror from 'codemirror';
-import onlineParser, { opt, list, butNot, t, p } from './utils/onlineParser';
+import onlineParser from './utils/onlineParser';
+import { LexRules, ParseRules, isIgnored } from './utils/Rules';
 
 
 /**
@@ -35,13 +36,14 @@ CodeMirror.defineMode('graphql', config => {
   const parser = onlineParser({
     eatWhitespace: stream => stream.eatWhile(isIgnored),
     LexRules,
-    ParseRules
+    ParseRules,
+    editorConfig: { tabSize: config.tabSize }
   });
 
   return {
     config,
     startState: parser.startState,
-    token: parser.getToken,
+    token: parser.token,
     indent,
     electricInput: /^\s*[})\]]/,
     fold: 'brace',
@@ -53,14 +55,6 @@ CodeMirror.defineMode('graphql', config => {
   };
 });
 
-const isIgnored = ch =>
-  ch === ' ' ||
-  ch === '\t' ||
-  ch === ',' ||
-  ch === '\n' ||
-  ch === '\r' ||
-  ch === '\uFEFF';
-
 function indent(state, textAfter) {
   var levels = state.levels;
   // If there is no stack of levels, use the current level.
@@ -68,161 +62,4 @@ function indent(state, textAfter) {
   var level = !levels || levels.length === 0 ? state.indentLevel :
     levels[levels.length - 1] - (this.electricInput.test(textAfter) ? 1 : 0);
   return level * this.config.indentUnit;
-}
-
-/**
- * The lexer rules. These are exactly as described by the spec.
- */
-var LexRules = {
-  // The Name token.
-  Name: /^[_A-Za-z][_0-9A-Za-z]*/,
-
-  // All Punctuation used in GraphQL
-  Punctuation: /^(?:!|\$|\(|\)|\.\.\.|:|=|@|\[|\]|\{|\})/,
-
-  // Combines the IntValue and FloatValue tokens.
-  Number: /^-?(?:0|(?:[1-9][0-9]*))(?:\.[0-9]*)?(?:[eE][+-]?[0-9]+)?/,
-
-  // Note the closing quote is made optional as an IDE experience improvment.
-  String: /^"(?:[^"\\]|\\(?:"|\/|\\|b|f|n|r|t|u[0-9a-fA-F]{4}))*"?/,
-};
-
-/**
- * The parser rules. These are very close to, but not exactly the same as the
- * spec. Minor deviations allow for a simpler implementation. The resulting
- * parser can parse everything the spec declares possible.
- */
-var ParseRules = {
-  Document: [ list('Definition') ],
-  Definition(token) {
-    switch (token.value) {
-      case 'query': return 'Query';
-      case 'mutation': return 'Mutation';
-      case 'subscription': return 'Subscription';
-      case 'fragment': return 'FragmentDefinition';
-      case '{': return 'ShortQuery';
-    }
-  },
-  // Note: instead of "Operation", these rules have been separated out.
-  Query: [
-    word('query'),
-    opt(name('def')),
-    opt('VariableDefinitions'),
-    list('Directive'),
-    'SelectionSet'
-  ],
-  ShortQuery: [ 'SelectionSet' ],
-  Mutation: [
-    word('mutation'),
-    opt(name('def')),
-    opt('VariableDefinitions'),
-    list('Directive'),
-    'SelectionSet'
-  ],
-  Subscription: [
-    word('subscription'),
-    opt(name('def')),
-    opt('VariableDefinitions'),
-    list('Directive'),
-    'SelectionSet'
-  ],
-  VariableDefinitions: [ p('('), list('VariableDefinition'), p(')') ],
-  VariableDefinition: [ 'Variable', p(':'), 'Type', opt('DefaultValue') ],
-  Variable: [ p('$', 'variable'), name('variable') ],
-  DefaultValue: [ p('='), 'Value' ],
-  SelectionSet: [ p('{'), list('Selection'), p('}') ],
-  Selection(token, stream) {
-    return token.value === '...' ?
-      stream.match(/[\s\u00a0,]*(on\b|@|{)/, false) ?
-        'InlineFragment' : 'FragmentSpread' :
-      stream.match(/[\s\u00a0,]*:/, false) ? 'AliasedField' : 'Field';
-  },
-  // Note: this minor deviation of "AliasedField" simplifies the lookahead.
-  AliasedField: [ name('qualifier'), p(':'), 'Field' ],
-  Field: [
-    name('property'), opt('Arguments'), list('Directive'), opt('SelectionSet')
-  ],
-  Arguments: [ p('('), list('Argument'), p(')') ],
-  Argument: [ name('attribute'), p(':'), 'Value' ],
-  FragmentSpread: [ p('...'), name('def'), list('Directive') ],
-  InlineFragment: [
-    p('...'),
-    opt('TypeCondition'),
-    list('Directive'),
-    'SelectionSet'
-  ],
-  FragmentDefinition: [
-    word('fragment'),
-    opt(butNot(name('def'), [ word('on') ])),
-    'TypeCondition',
-    list('Directive'),
-    'SelectionSet'
-  ],
-  TypeCondition: [
-    word('on'),
-    type('atom'),
-  ],
-  // Variables could be parsed in cases where only Const is expected by spec.
-  Value(token) {
-    switch (token.kind) {
-      case 'Number': return 'NumberValue';
-      case 'String': return 'StringValue';
-      case 'Punctuation':
-        switch (token.value) {
-          case '[': return 'ListValue';
-          case '{': return 'ObjectValue';
-          case '$': return 'Variable';
-        }
-        return null;
-      case 'Name':
-        switch (token.value) {
-          case 'true': case 'false': return 'BooleanValue';
-        }
-        return 'EnumValue';
-    }
-  },
-  NumberValue: [ t('Number', 'number') ],
-  StringValue: [ t('String', 'string') ],
-  BooleanValue: [ t('Name', 'builtin') ],
-  EnumValue: [ name('string-2') ],
-  ListValue: [ p('['), list('Value'), p(']') ],
-  ObjectValue: [ p('{'), list('ObjectField'), p('}') ],
-  ObjectField: [ name('attribute'), p(':'), 'Value' ],
-  Type(token) {
-    return token.value === '[' ? 'ListType' : 'NamedType';
-  },
-  // NonNullType has been merged into ListType and NamedType to simplify.
-  ListType: [ p('['), 'NamedType', p(']'), opt(p('!')) ],
-  NamedType: [ name('atom'), opt(p('!')) ],
-  Directive: [ p('@', 'meta'), name('meta'), opt('Arguments') ],
-};
-
-// A keyword Token.
-function word(value) {
-  return {
-    style: 'keyword',
-    match: token => token.kind === 'Name' && token.value === value
-  };
-}
-
-// A Name Token which will decorate the state with a `name`.
-function name(style) {
-  return {
-    style,
-    match: token => token.kind === 'Name',
-    update(state, token) {
-      state.name = token.value;
-    }
-  };
-}
-
-// A Name Token which will decorate the previous state with a `type`.
-function type(style) {
-  return {
-    style,
-    match: token => token.kind === 'Name',
-    update(state, token) {
-      state.prevState.type = token.value;
-    }
-  };
 }

--- a/src/utils/CharacterStream.js
+++ b/src/utils/CharacterStream.js
@@ -1,0 +1,153 @@
+/**
+ *  Copyright (c) 2015, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+/**
+ * CharacterStream implements a stream of character tokens given a source text.
+ * The API design follows that of CodeMirror.StringStream.
+ *
+ * Required:
+ *
+ *      sourceText: (string), A raw GraphQL source text. Works best if a line
+ *        is supplied.
+ *
+ */
+
+export default class CharacterStream {
+  constructor(sourceText: string): void {
+    this._pos = 0;
+    this._sourceText = sourceText;
+  }
+
+  _testNextCharacter(pattern: mixed) {
+    let character = this._sourceText.charAt(this._pos);
+    let isMatched = false;
+    if (typeof pattern === 'string') {
+      isMatched = character === pattern;
+    } else {
+      isMatched = pattern.test ? pattern.test(character) : pattern(character);
+    }
+    return isMatched;
+  }
+
+  eol(): boolean {
+    return this._sourceText.length === this._pos;
+  }
+
+  sol(): boolean {
+    return this._pos === 0;
+  }
+
+  peek(): string | void {
+    return this._sourceText.charAt(this._pos) !== '\n' ?
+      this._sourceText.charAt(this._pos) : null;
+  }
+
+  next(): string {
+    const char = this._sourceText.charAt(this._pos);
+    this._pos ++;
+    return char;
+  }
+
+  eat(pattern: mixed): string | void {
+    const isMatched = this._testNextCharacter(pattern);
+    if (isMatched) {
+      this._pos ++;
+      return isMatched;
+    }
+    return undefined;
+  }
+
+  eatWhile(match: mixed): boolean {
+    let isMatched = this._testNextCharacter(match);
+    let didEat = isMatched;
+
+    while (isMatched) {
+      this._pos ++;
+      isMatched = this._testNextCharacter(match);
+      didEat = true;
+    }
+
+    return didEat;
+  }
+
+  eatSpace(): boolean {
+    return this.eatWhile(/[\s\u00a0]/);
+  }
+
+  skipToEnd(): void {
+    this._pos = this._sourceText.length;
+  }
+
+  skipTo(position): void {
+    this._pos = position;
+  }
+
+  match(
+    pattern: mixed,
+    consume: ?boolean = true,
+    caseFold: boolean
+  ): Array<string> | boolean {
+    let token = null;
+    let match = null;
+
+    switch (typeof pattern) {
+      case 'string':
+        const regex = new RegExp(pattern, (caseFold ? 'i' : ''));
+        match = regex.test(this._sourceText.substr(this._pos, pattern.length));
+        token = pattern;
+        break;
+      case 'object': // RegExp
+      case 'function':
+        match = this._sourceText.slice(this._pos).match(pattern);
+        token = match && match[0];
+        break;
+    }
+
+    if (match && match.index === 0) {
+      if (consume) {
+        this._pos += token.length;
+      }
+      return match;
+    }
+
+    // No match available.
+    return false;
+  }
+
+  backUp(num: number): void {
+    this._pos -= num;
+  }
+
+  column(): number {
+    return this._pos;
+  }
+
+  indentation(): number {
+    const match = this._sourceText.match(/\s*/);
+    let indent = 0;
+    if (match && match.index === 0) {
+      const whitespaces = match[0];
+      let pos = 0;
+      while (whitespaces.length > pos) {
+        if (whitespaces.charCodeAt(pos) === 9) {
+          indent += 2;
+        } else {
+          indent++;
+        }
+        pos++;
+      }
+    }
+
+    return indent;
+  }
+
+  current(): string {
+    return this._sourceText.slice(0, this._pos);
+  }
+}

--- a/src/utils/RuleHelpers.js
+++ b/src/utils/RuleHelpers.js
@@ -1,0 +1,41 @@
+/**
+ *  Copyright (c) 2015, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ */
+// These functions help build matching rules for ParseRules.
+
+// An optional rule.
+export function opt(ofRule) {
+  return { ofRule };
+}
+
+// A list of another rule.
+export function list(ofRule, separator) {
+  return { ofRule, isList: true, separator };
+}
+
+// An constraint described as `but not` in the GraphQL spec.
+export function butNot(rule, exclusions) {
+  var ruleMatch = rule.match;
+  rule.match =
+    token => ruleMatch(token) &&
+    exclusions.every(exclusion => !exclusion.match(token));
+  return rule;
+}
+
+// Token of a kind
+export function t(kind, style) {
+  return { style, match: token => token.kind === kind };
+}
+
+// Punctuator
+export function p(value, style) {
+  return {
+    style: style || 'punctuation',
+    match: token => token.kind === 'Punctuation' && token.value === value
+  };
+}

--- a/src/utils/Rules.js
+++ b/src/utils/Rules.js
@@ -1,0 +1,178 @@
+/**
+ *  Copyright (c) 2015, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+import { opt, list, butNot, t, p } from '../utils/RuleHelpers';
+
+ /**
+  * Whitespace tokens defined in GraphQL spec.
+  */
+export const isIgnored = ch =>
+  ch === ' ' ||
+  ch === '\t' ||
+  ch === ',' ||
+  ch === '\n' ||
+  ch === '\r' ||
+  ch === '\uFEFF';
+
+/**
+ * The lexer rules. These are exactly as described by the spec.
+ */
+export const LexRules = {
+  // The Name token.
+  Name: /^[_A-Za-z][_0-9A-Za-z]*/,
+
+  // All Punctuation used in GraphQL
+  Punctuation: /^(?:!|\$|\(|\)|\.\.\.|:|=|@|\[|\]|\{|\})/,
+
+  // Combines the IntValue and FloatValue tokens.
+  Number: /^-?(?:0|(?:[1-9][0-9]*))(?:\.[0-9]*)?(?:[eE][+-]?[0-9]+)?/,
+
+  // Note the closing quote is made optional as an IDE experience improvment.
+  String: /^"(?:[^"\\]|\\(?:"|\/|\\|b|f|n|r|t|u[0-9a-fA-F]{4}))*"?/,
+};
+
+/**
+ * The parser rules. These are very close to, but not exactly the same as the
+ * spec. Minor deviations allow for a simpler implementation. The resulting
+ * parser can parse everything the spec declares possible.
+ */
+export const ParseRules = {
+  Document: [ list('Definition') ],
+  Definition(token) {
+    switch (token.value) {
+      case 'query': return 'Query';
+      case 'mutation': return 'Mutation';
+      case 'subscription': return 'Subscription';
+      case 'fragment': return 'FragmentDefinition';
+      case '{': return 'ShortQuery';
+    }
+  },
+  // Note: instead of "Operation", these rules have been separated out.
+  Query: [
+    word('query'),
+    opt(name('def')),
+    opt('VariableDefinitions'),
+    list('Directive'),
+    'SelectionSet'
+  ],
+  ShortQuery: [ 'SelectionSet' ],
+  Mutation: [
+    word('mutation'),
+    opt(name('def')),
+    opt('VariableDefinitions'),
+    list('Directive'),
+    'SelectionSet'
+  ],
+  Subscription: [
+    word('subscription'),
+    opt(name('def')),
+    opt('VariableDefinitions'),
+    list('Directive'),
+    'SelectionSet'
+  ],
+  VariableDefinitions: [ p('('), list('VariableDefinition'), p(')') ],
+  VariableDefinition: [ 'Variable', p(':'), 'Type', opt('DefaultValue') ],
+  Variable: [ p('$', 'variable'), name('variable') ],
+  DefaultValue: [ p('='), 'Value' ],
+  SelectionSet: [ p('{'), list('Selection'), p('}') ],
+  Selection(token, stream) {
+    return token.value === '...' ?
+      stream.match(/[\s\u00a0,]*(on\b|@|{)/, false) ?
+        'InlineFragment' : 'FragmentSpread' :
+      stream.match(/[\s\u00a0,]*:/, false) ? 'AliasedField' : 'Field';
+  },
+  // Note: this minor deviation of "AliasedField" simplifies the lookahead.
+  AliasedField: [ name('qualifier'), p(':'), 'Field' ],
+  Field: [
+    name('property'), opt('Arguments'), list('Directive'), opt('SelectionSet')
+  ],
+  Arguments: [ p('('), list('Argument'), p(')') ],
+  Argument: [ name('attribute'), p(':'), 'Value' ],
+  FragmentSpread: [ p('...'), name('def'), list('Directive') ],
+  InlineFragment: [
+    p('...'),
+    opt('TypeCondition'),
+    list('Directive'),
+    'SelectionSet'
+  ],
+  FragmentDefinition: [
+    word('fragment'),
+    opt(butNot(name('def'), [ word('on') ])),
+    'TypeCondition',
+    list('Directive'),
+    'SelectionSet'
+  ],
+  TypeCondition: [
+    word('on'),
+    type('atom'),
+  ],
+  // Variables could be parsed in cases where only Const is expected by spec.
+  Value(token) {
+    switch (token.kind) {
+      case 'Number': return 'NumberValue';
+      case 'String': return 'StringValue';
+      case 'Punctuation':
+        switch (token.value) {
+          case '[': return 'ListValue';
+          case '{': return 'ObjectValue';
+          case '$': return 'Variable';
+        }
+        return null;
+      case 'Name':
+        switch (token.value) {
+          case 'true': case 'false': return 'BooleanValue';
+        }
+        return 'EnumValue';
+    }
+  },
+  NumberValue: [ t('Number', 'number') ],
+  StringValue: [ t('String', 'string') ],
+  BooleanValue: [ t('Name', 'builtin') ],
+  EnumValue: [ name('string-2') ],
+  ListValue: [ p('['), list('Value'), p(']') ],
+  ObjectValue: [ p('{'), list('ObjectField'), p('}') ],
+  ObjectField: [ name('attribute'), p(':'), 'Value' ],
+  Type(token) {
+    return token.value === '[' ? 'ListType' : 'NamedType';
+  },
+  // NonNullType has been merged into ListType and NamedType to simplify.
+  ListType: [ p('['), 'NamedType', p(']'), opt(p('!')) ],
+  NamedType: [ name('atom'), opt(p('!')) ],
+  Directive: [ p('@', 'meta'), name('meta'), opt('Arguments') ],
+};
+
+// A keyword Token.
+function word(value) {
+  return {
+    style: 'keyword',
+    match: token => token.kind === 'Name' && token.value === value
+  };
+}
+
+// A Name Token which will decorate the state with a `name`.
+function name(style) {
+  return {
+    style,
+    match: token => token.kind === 'Name',
+    update(state, token) {
+      state.name = token.value;
+    }
+  };
+}
+
+// A Name Token which will decorate the previous state with a `type`.
+function type(style) {
+  return {
+    style,
+    match: token => token.kind === 'Name',
+    update(state, token) {
+      state.prevState.type = token.value;
+    }
+  };
+}

--- a/src/utils/__tests__/onlineParser-test.js
+++ b/src/utils/__tests__/onlineParser-test.js
@@ -1,0 +1,33 @@
+/**
+ *  Copyright (c) 2015, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+import { expect } from 'chai';
+import { readFileSync } from 'fs';
+import { describe, it } from 'mocha';
+import { join } from 'path';
+
+import runParser from '../runParser';
+import { LexRules, ParseRules, isIgnored } from '../Rules';
+
+describe('onlineParser', () => {
+  it('parses kitchen-sink without invalidchar', () => {
+    const kitchenSink = readFileSync(
+      join(__dirname, '../../__tests__/kitchen-sink.graphql'),
+      { encoding: 'utf8' }
+    );
+
+    runParser(kitchenSink, {
+      eatWhitespace: stream => stream.eatWhile(isIgnored),
+      LexRules,
+      ParseRules
+    }, (stream, state, style) => {
+      expect(style).to.not.equal('invalidchar');
+    });
+  });
+});

--- a/src/utils/runParser.js
+++ b/src/utils/runParser.js
@@ -1,0 +1,25 @@
+/**
+ *  Copyright (c) 2015, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+import CharacterStream from './CharacterStream';
+import onlineParser from './onlineParser';
+
+export default function runParser(sourceText, parserOptions, callbackFn) {
+  const parser = onlineParser(parserOptions);
+  const state = parser.startState();
+  const lines = sourceText.split('\n');
+
+  lines.forEach(line => {
+    const stream = new CharacterStream(line);
+    while (!stream.eol()) {
+      const style = parser.token(stream, state);
+      callbackFn(stream, state, style);
+    }
+  });
+}

--- a/src/variables/mode.js
+++ b/src/variables/mode.js
@@ -9,8 +9,8 @@
 
 import CodeMirror from 'codemirror';
 
-import onlineParser, { list, t, p } from '../utils/onlineParser';
-
+import onlineParser from '../utils/onlineParser';
+import { list, t, p } from '../utils/RuleHelpers';
 
 /**
  * This mode defines JSON, but provides a data-laden parser state to enable
@@ -20,13 +20,14 @@ CodeMirror.defineMode('graphql-variables', config => {
   const parser = onlineParser({
     eatWhitespace: stream => stream.eatSpace(),
     LexRules,
-    ParseRules
+    ParseRules,
+    editorConfig: { tabSize: config.tabSize }
   });
 
   return {
     config,
     startState: parser.startState,
-    token: parser.getToken,
+    token: parser.token,
     indent,
     electricInput: /^\s*[}\]]/,
     fold: 'brace',


### PR DESCRIPTION
As a preparation step towards extracting out a GraphQL language service-related code, this PR intoduces `GraphQLStream` object that serves almost exactly same purpose as CodeMirror.StringStream. A few differences include using a GraphQL `lexer` (hence different logics for checking comments/EOF).

With `GraphQLStream`, `onlineParser` is completely separated from `CodeMirror` and only needs the editor-specific configuration (e.g. tabSize). For now `onlineParser` should be used similar to how `CodeMirror.runMode` executes - given a raw GraphQL source text, first split into multiple lines, feed each line into `GraphQLStream` object, run `getToken` function until the end of the line (`stream.eol()`), and repeat the process for each line.

The state object may be initialized by executing `parser.startState()`, and the state reference is updated as the parser visits each token, allowing the query context to be built and used for services such as typeahead.