### PR TITLE
fix jsonParse not recognizing escaped characters

### DIFF
--- a/src/utils/__tests__/jsonParse-test.js
+++ b/src/utils/__tests__/jsonParse-test.js
@@ -1,0 +1,39 @@
+/**
+ *  Copyright (c) 2015, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import jsonParse from '../jsonParse';
+
+describe('jsonParse', () => {
+  function checkEscapedString(str, key, value) {
+    const ast = jsonParse(str);
+    expect(ast.kind).to.equal('Object');
+    expect(ast.members[0].key).to.deep.equal(key);
+    expect(ast.members[0].value).to.deep.equal(value);
+  }
+
+  it('correctly parses escaped strings', () => {
+    checkEscapedString(
+      '{ "test": "\\"" }',
+      { kind: 'String', start: 2, end: 8, value: 'test' },
+      { kind: 'String', start: 10, end: 14, value: '"' }
+    );
+    checkEscapedString(
+      '{ "test": "\\\\" }',
+      { kind: 'String', start: 2, end: 8, value: 'test' },
+      { kind: 'String', start: 10, end: 14, value: '\\' }
+    );
+    checkEscapedString(
+      '{ "slash": "\\/" }',
+      { kind: 'String', start: 2, end: 9, value: 'slash' },
+      { kind: 'String', start: 11, end: 15, value: '/' }
+    );
+  });
+});

--- a/src/utils/jsonParse.js
+++ b/src/utils/jsonParse.js
@@ -209,7 +209,6 @@ function lex() {
 function readString() {
   ch();
   while (code !== 34 && code > 31) {
-    ch();
     if (code === 92) { // \
       ch();
       switch (code) {
@@ -235,6 +234,8 @@ function readString() {
       }
     } else if (end === strLen) {
       throw syntaxError('Unterminated string.');
+    } else {
+      ch();
     }
   }
 


### PR DESCRIPTION
Added tests for this.
Basically if there is a backslash character to escape characters, the lexer would prematurely move the stream a character forward. This wasn't a problem until someone came across `"\""` case, which broke `GraphiQL`. The fix is to prevent advancing the character stream until the stream takes a look at the current character as it enters the loop.