### PR TITLE
Adds schema IDL to parse rules.

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "codemirror": "5.13.4",
     "eslint": "1.10.3",
     "flow-bin": "0.22.1",
-    "graphql": "0.5.0",
+    "graphql": "0.6.0",
     "jsdom": "8.3.0",
     "mocha": "2.4.5",
     "sane": "1.3.4"

--- a/src/__tests__/mode-test.js
+++ b/src/__tests__/mode-test.js
@@ -70,13 +70,24 @@ describe('graphql-mode', () => {
     });
   });
 
-  var kitchenSink = readFileSync(
-    join(__dirname, '/kitchen-sink.graphql'),
-    { encoding: 'utf8' }
-  );
-
   it('parses kitchen-sink query without invalidchar', () => {
+    var kitchenSink = readFileSync(
+      join(__dirname, '/kitchen-sink.graphql'),
+      { encoding: 'utf8' }
+    );
+
     CodeMirror.runMode(kitchenSink, 'graphql', (token, style) => {
+      expect(style).to.not.equal('invalidchar');
+    });
+  });
+
+  it('parses schema-kitchen-sink query without invalidchar', () => {
+    var schemaKitchenSink = readFileSync(
+      join(__dirname, '/schema-kitchen-sink.graphql'),
+      { encoding: 'utf8' }
+    );
+
+    CodeMirror.runMode(schemaKitchenSink, 'graphql', (token, style) => {
       expect(style).to.not.equal('invalidchar');
     });
   });

--- a/src/__tests__/schema-kitchen-sink.graphql
+++ b/src/__tests__/schema-kitchen-sink.graphql
@@ -1,0 +1,75 @@
+# Copyright (c) 2016, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+
+schema {
+  query: QueryType
+  mutation: MutationType
+}
+
+type Foo implements Bar {
+  one: Type
+  two(argument: InputType!): Type
+  three(argument: InputType, other: String): Int
+  four(argument: String = "string"): String
+  five(argument: [String] = ["string", "string"]): String
+  six(argument: InputType = {key: "value"}): Type
+}
+
+type AnnotatedObject @onObject(arg: "value") {
+  annotatedField(arg: Type = "default" @onArg): Type @onField
+}
+
+interface Bar {
+  one: Type
+  four(argument: String = "string"): String
+}
+
+interface AnnotatedInterface @onInterface {
+  annotatedField(arg: Type @onArg): Type @onField
+}
+
+union Feed = Story | Article | Advert
+
+union AnnotatedUnion @onUnion = A | B
+
+scalar CustomScalar
+
+scalar AnnotatedScalar @onScalar
+
+enum Site {
+  DESKTOP
+  MOBILE
+}
+
+enum AnnotatedEnum @onEnum {
+  ANNOTATED_VALUE @onEnumValue
+  OTHER_VALUE
+}
+
+input InputType {
+  key: String!
+  answer: Int = 42
+}
+
+input AnnotatedInput @onInputObjectType {
+  annotatedField: Type @onField
+}
+
+extend type Foo {
+  seven(argument: [[String!]!]!): Type
+}
+
+extend type Foo @onType {}
+
+type NoFields {}
+
+directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+directive @include(if: Boolean!)
+  on FIELD
+   | FRAGMENT_SPREAD
+   | INLINE_FRAGMENT

--- a/src/utils/__tests__/onlineParser-test.js
+++ b/src/utils/__tests__/onlineParser-test.js
@@ -16,6 +16,7 @@ import runParser from '../runParser';
 import { LexRules, ParseRules, isIgnored } from '../Rules';
 
 describe('onlineParser', () => {
+
   it('parses kitchen-sink without invalidchar', () => {
     const kitchenSink = readFileSync(
       join(__dirname, '../../__tests__/kitchen-sink.graphql'),
@@ -30,4 +31,24 @@ describe('onlineParser', () => {
       expect(style).to.not.equal('invalidchar');
     });
   });
+
+  it('parses schema-kitchen-sink without invalidchar', () => {
+    const schemaKitchenSink = readFileSync(
+      join(__dirname, '../../__tests__/schema-kitchen-sink.graphql'),
+      { encoding: 'utf8' }
+    );
+
+    runParser(schemaKitchenSink, {
+      eatWhitespace: stream => stream.eatWhile(isIgnored),
+      LexRules,
+      ParseRules
+    }, (stream, state, style) => {
+      if (style === 'invalidchar') {
+        console.error(state);
+        console.error(stream);
+      }
+      expect(style).to.not.equal('invalidchar');
+    });
+  });
+
 });

--- a/src/utils/onlineParser.js
+++ b/src/utils/onlineParser.js
@@ -167,6 +167,9 @@ function restoreState(state) {
 
 // Push a new rule onto the state.
 function pushRule(ParseRules, state, ruleKind) {
+  if (!ParseRules[ruleKind]) {
+    throw new TypeError('Unknown rule: ' + ruleKind);
+  }
   state.prevState = assign({}, state);
   state.kind = ruleKind;
   state.name = null;


### PR DESCRIPTION
This adds the GraphQL schema definition language to the online parser rules. GraphiQL will likely still complain about validation issues of using the schema language, but at least now it will be properly highlighted!

**Before:**

<img width="835" alt="screenshot 2016-08-24 23 03 35" src="https://cloud.githubusercontent.com/assets/50130/17958660/4b56d054-6a50-11e6-9e61-03e05d43c1fa.png">

**After:**

<img width="608" alt="screenshot 2016-08-24 23 10 45" src="https://cloud.githubusercontent.com/assets/50130/17958659/4b5515e8-6a50-11e6-8319-d1e515afbc16.png">
