### PR TITLE
Support `null`

### DIFF
--- a/src/utils/Rules.js
+++ b/src/utils/Rules.js
@@ -144,12 +144,16 @@ export const ParseRules = {
         switch (token.value) {
           case 'true': case 'false': return 'BooleanValue';
         }
+        if (token.value === 'null') {
+          return 'NullValue';
+        }
         return 'EnumValue';
     }
   },
   NumberValue: [ t('Number', 'number') ],
   StringValue: [ t('String', 'string') ],
   BooleanValue: [ t('Name', 'builtin') ],
+  NullValue: [ t('Name', 'keyword') ],
   EnumValue: [ name('string-2') ],
   ListValue: [ p('['), list('Value'), p(']') ],
   ObjectValue: [ p('{'), list('ObjectField'), p('}') ],


### PR DESCRIPTION
Since graphql/graphql-js#544 landed, it's time to support `null` in Rules

I don't know how to enhance `hint` to offer `null` as valid value correctly, help with this wanted! :slightly_smiling_face: 