### PR TITLE
Bugfix/aliased field arguments and directives not populating hint list

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,11 +26,13 @@
     "LICENSE"
   ],
   "options": {
-    "mocha": "--full-trace --require resources/mocha-bootload src/**/__tests__/**/*-test.js"
+    "mocha": "--full-trace --require resources/mocha-bootload src/**/__tests__/**/*-test.js",
+    "mocha_tdd": "--full-trace --watch --require resources/mocha-bootload src/**/__tests__/**/*-test.js"
   },
   "scripts": {
     "test": "npm run lint && npm run testonly",
     "testonly": "babel-node ./node_modules/.bin/_mocha $npm_package_options_mocha",
+    "testwatch": "babel-node --inspect ./node_modules/.bin/_mocha $npm_package_options_mocha_tdd",
     "lint": "eslint src",
     "check": "flow check",
     "build": "babel src --ignore __tests__ --out-dir .",

--- a/src/__tests__/hint-test.js
+++ b/src/__tests__/hint-test.js
@@ -86,7 +86,7 @@ describe('graphql-hint', () => {
     checkSuggestions(argumentNames, suggestions.list);
   });
 
-  it.only('provides correct argument suggestions when using aliases', async () => {
+  it('provides correct argument suggestions when using aliases', async () => {
     var suggestions = await getHintSuggestions(
       '{ aliasTest: hasArgs ( ', { line: 0, ch: 23 });
     var argumentNames =

--- a/src/__tests__/hint-test.js
+++ b/src/__tests__/hint-test.js
@@ -86,9 +86,24 @@ describe('graphql-hint', () => {
     checkSuggestions(argumentNames, suggestions.list);
   });
 
+  it.only('provides correct argument suggestions when using aliases', async () => {
+    var suggestions = await getHintSuggestions(
+      '{ aliasTest: hasArgs ( ', { line: 0, ch: 23 });
+    var argumentNames =
+      TestSchema.getQueryType().getFields().hasArgs.args.map(arg => arg.name);
+    checkSuggestions(argumentNames, suggestions.list);
+  });
+
   it('provides correct directive suggestions', async () => {
     var suggestions = await getHintSuggestions(
       '{ test (@', { line: 0, ch: 9 });
+    var directiveNames = [ 'include', 'skip' ];
+    checkSuggestions(directiveNames, suggestions.list);
+  });
+
+  it('provides correct directive suggestions when using aliases', async () => {
+    var suggestions = await getHintSuggestions(
+      '{ aliasTest: test (@', { line: 0, ch: 20 });
     var directiveNames = [ 'include', 'skip' ];
     checkSuggestions(directiveNames, suggestions.list);
   });

--- a/src/utils/getHintsAtPosition.js
+++ b/src/utils/getHintsAtPosition.js
@@ -235,6 +235,7 @@ function canUseDirective(kind, directive) {
     case 'Subscription':
       return locations.indexOf('SUBSCRIPTION') !== -1;
     case 'Field':
+    case 'AliasedField':
       return locations.indexOf('FIELD') !== -1;
     case 'FragmentDefinition':
       return locations.indexOf('FRAGMENT_DEFINITION') !== -1;

--- a/src/utils/getHintsAtPosition.js
+++ b/src/utils/getHintsAtPosition.js
@@ -296,6 +296,9 @@ function getTypeInfo(schema, tokenState) {
             info.fieldDef && info.fieldDef.args :
           state.prevState.kind === 'Directive' ?
             info.directiveDef && info.directiveDef.args :
+          state.prevState.kind === 'AliasedField' ?
+            state.prevState.name &&
+            getFieldDef(schema, info.parentType, state.prevState.name).args :
             null;
         break;
       case 'Argument':


### PR DESCRIPTION
Fixes a consumer issue: https://github.com/graphql/graphiql/issues/196. Also adds a `npm run testwatch` for TDD style development, which was used to surface this bug and squash it.