### PR TITLE
Drop the beta designation from the graphql dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "prepublish": ". ./resources/prepublish.sh"
   },
   "peerDependencies": {
-    "graphql": "^0.6.0 || ^0.7.0 || ^0.8.0-b",
+    "graphql": "^0.6.0 || ^0.7.0 || ^0.8.0",
     "codemirror": "^5.6.0"
   },
   "devDependencies": {


### PR DESCRIPTION
The beta is long gone, long live v0.8.2.