### PR TITLE
Improve parser state for special tokens.

### DIFF
--- a/src/utils/Rules.js
+++ b/src/utils/Rules.js
@@ -35,6 +35,9 @@ export const LexRules = {
 
   // Note the closing quote is made optional as an IDE experience improvment.
   String: /^"(?:[^"\\]|\\(?:"|\/|\\|b|f|n|r|t|u[0-9a-fA-F]{4}))*"?/,
+
+  // Comments consume entire lines.
+  Comment: /^#.*/,
 };
 
 /**

--- a/src/variables/hint.js
+++ b/src/variables/hint.js
@@ -53,7 +53,11 @@ CodeMirror.registerHelper('hint', 'graphql-variables', (editor, options) => {
 });
 
 function getVariablesHint(cur, token, options) {
-  const state = token.state;
+  // If currently parsing an invalid state, attempt to hint to the prior state.
+  const state = token.state.kind === 'Invalid' ?
+    token.state.prevState :
+    token.state;
+
   const kind = state.kind;
   const step = state.step;
 


### PR DESCRIPTION
Currently, the onlineParser doesn't alter token state for special tokens like `comment` or `invalidchar`. When you load the token state for one of these tokens, it appears to be whatever came before it. When building "intelisense" features for IDEs this can be a complicating factor.

This proposes adding two new special parse rules "Comment" and "Invalid" and altering the parser behavior to detect and insert them when necessary.

This also results in onlineParser becoming more generic with respect to Comment lexer rules. Previously onlineParser knew more than it should about how comments are defined. Now, the provided parse rules (specifically the lexer rules) supply the definition for `Comment`.

Finally, this removes global state from the parser when saving and resuming backup states, keeping that context contained within the parser function. That removes the possibility for poisoning the parse state.