### PR TITLE
Fix list separators in onlineParser

### DIFF
--- a/src/utils/Rules.js
+++ b/src/utils/Rules.js
@@ -216,10 +216,9 @@ export const ParseRules = {
     name('atom'),
     list('Directive'),
     p('='),
-    name('atom'),
-    list('UnionMember')
+    list('UnionMember', p('|'))
   ],
-  UnionMember: [ p('|'), name('atom') ],
+  UnionMember: [ name('atom') ],
   EnumDef: [
     word('enum'),
     name('atom'),
@@ -244,10 +243,9 @@ export const ParseRules = {
     name('meta'),
     opt('ArgumentsDef'),
     word('on'),
-    name('string-2'),
-    list('DirectiveLocation')
+    list('DirectiveLocation', p('|'))
   ],
-  DirectiveLocation: [ p('|'), name('string-2') ]
+  DirectiveLocation: [ name('string-2') ]
 };
 
 // A keyword Token.

--- a/src/utils/onlineParser.js
+++ b/src/utils/onlineParser.js
@@ -195,11 +195,11 @@ function advanceRule(state, successful) {
   // If this is advancing successfully and the current state is a list, give
   // it an opportunity to repeat itself.
   if (isList(state)) {
-    if (state.rule[state.step].separator) {
+    const separator = state.rule[state.step].separator;
+    if (separator) {
       state.needsSeperator = !state.needsSeperator;
-      // If the next list iteration might accept a non-separator, then give it
-      // an opportunity to repeat.
-      if (!state.needsSeperator) {
+      // If the separator was optional, then give it an opportunity to repeat.
+      if (!state.needsSeperator && separator.ofRule) {
         return;
       }
     }

--- a/src/variables/mode.js
+++ b/src/variables/mode.js
@@ -10,7 +10,7 @@
 import CodeMirror from 'codemirror';
 
 import onlineParser from '../utils/onlineParser';
-import { list, t, p } from '../utils/RuleHelpers';
+import { list, opt, t, p } from '../utils/RuleHelpers';
 
 /**
  * This mode defines JSON, but provides a data-laden parser state to enable
@@ -68,7 +68,7 @@ const LexRules = {
  * The parser rules for JSON.
  */
 const ParseRules = {
-  Document: [ p('{'), list('Variable', p(',')), p('}') ],
+  Document: [ p('{'), list('Variable', opt(p(','))), p('}') ],
   Variable: [ namedKey('variable'), p(':'), 'Value' ],
   Value(token) {
     switch (token.kind) {
@@ -92,8 +92,8 @@ const ParseRules = {
   StringValue: [ t('String', 'string') ],
   BooleanValue: [ t('Keyword', 'builtin') ],
   NullValue: [ t('Keyword', 'keyword') ],
-  ListValue: [ p('['), list('Value', p(',')), p(']') ],
-  ObjectValue: [ p('{'), list('ObjectField', p(',')), p('}') ],
+  ListValue: [ p('['), list('Value', opt(p(','))), p(']') ],
+  ObjectValue: [ p('{'), list('ObjectField', opt(p(','))), p('}') ],
   ObjectField: [ namedKey('attribute'), p(':'), 'Value' ],
 };
 


### PR DESCRIPTION
This fixes the onlineParser's list separator feature which allows for a more natural expression of the union members and directive locations grammars.