### PR TITLE
add deprecation info to hint list

### DIFF
--- a/src/utils/getHintsAtPosition.js
+++ b/src/utils/getHintsAtPosition.js
@@ -122,7 +122,9 @@ export default function getHintsAtPosition(schema, sourceText, cursor, token) {
       return hintList(cursor, token, values.map(value => ({
         text: value.name,
         type: namedInputType,
-        description: value.description
+        description: value.description,
+        isDeprecated: value.isDeprecated,
+        deprecationReason: value.deprecationReason
       })));
     } else if (namedInputType === GraphQLBoolean) {
       return hintList(cursor, token, [


### PR DESCRIPTION
I would like to expose these values so that the graphql IDE can use them to let you know if an ENUM value is deprecated as you type, in the suggestions list. I will submit a PR to graphiql for that as well.