### PR TITLE
[RFC] Info tooltips and Jump to definition.

### DIFF
--- a/src/info.js
+++ b/src/info.js
@@ -1,0 +1,178 @@
+/* @flow */
+/**
+ *  Copyright (c) 2017, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+import { GraphQLList, GraphQLNonNull } from 'graphql';
+import CodeMirror from 'codemirror';
+
+import getTypeInfo from './utils/getTypeInfo';
+import {
+  getFieldReference,
+  getDirectiveReference,
+  getArgumentReference,
+  getTypeReference
+} from './utils/SchemaReference';
+import './utils/info-addon';
+
+/**
+ * Registers GraphQL "info" tooltips for CodeMirror.
+ *
+ * When hovering over a token, this presents a tooltip explaining it.
+ *
+ * Options:
+ *
+ *   - schema: GraphQLSchema provides positionally relevant info.
+ *   - hoverTime: The number of ms to wait before showing info. (Default 500)
+ *   - renderDescription: Convert a description to some HTML, Useful since
+ *                        descriptions are often Markdown formatted.
+ *   - onClick: A function called when a named thing is clicked.
+ *
+ */
+CodeMirror.registerHelper('info', 'graphql', (token, options) => {
+  if (!options.schema || !token.state) {
+    return;
+  }
+
+  const state = token.state;
+  const kind = state.kind;
+  const step = state.step;
+  const typeInfo = getTypeInfo(options.schema, token.state);
+
+  // Given a Schema and a Token, produce the contents of an info tooltip.
+  // To do this, create a div element that we will render "into" and then pass
+  // it to various rendering functions.
+  if (kind === 'Field' && step === 0 && typeInfo.fieldDef ||
+      kind === 'AliasedField' && step === 2 && typeInfo.fieldDef) {
+    const into = document.createElement('div');
+    renderField(into, typeInfo, options);
+    renderDescription(into, options, typeInfo.fieldDef);
+    return into;
+  } else if (kind === 'Directive' && step === 1 && typeInfo.directiveDef) {
+    const into = document.createElement('div');
+    renderDirective(into, typeInfo, options);
+    renderDescription(into, options, typeInfo.directiveDef);
+    return into;
+  } else if (kind === 'Argument' && step === 0 && typeInfo.argDef) {
+    const into = document.createElement('div');
+    renderArg(into, typeInfo, options);
+    renderDescription(into, options, typeInfo.argDef);
+    return into;
+  } else if (kind === 'NamedType' && step === 0 &&
+             typeInfo.type && typeInfo.type.description) {
+    const into = document.createElement('div');
+    renderType(into, typeInfo, options, typeInfo.type);
+    renderDescription(into, options, typeInfo.type);
+    return into;
+  }
+});
+
+function renderField(into, typeInfo, options) {
+  renderQualifiedField(into, typeInfo, options);
+  renderTypeAnnotation(into, typeInfo, options, typeInfo.type);
+}
+
+function renderQualifiedField(into, typeInfo, options) {
+  const fieldName = typeInfo.fieldDef.name;
+  if (fieldName.slice(0, 2) !== '__') {
+    renderType(into, typeInfo, options, typeInfo.parentType);
+    text(into, '.');
+  }
+  text(into, fieldName, 'field-name', options, getFieldReference(typeInfo));
+}
+
+function renderDirective(into, typeInfo, options) {
+  const name = '@' + typeInfo.directiveDef.name;
+  text(into, name, 'directive-name', options, getDirectiveReference(typeInfo));
+}
+
+function renderArg(into, typeInfo, options) {
+  if (typeInfo.directiveDef) {
+    renderDirective(into, typeInfo, options);
+  } else if (typeInfo.fieldDef) {
+    renderQualifiedField(into, typeInfo, options);
+  }
+
+  const name = typeInfo.argDef.name;
+  text(into, '(');
+  text(into, name, 'arg-name', options, getArgumentReference(typeInfo));
+  renderTypeAnnotation(into, typeInfo, options, typeInfo.inputType);
+  text(into, ')');
+}
+
+function renderTypeAnnotation(into, typeInfo, options, t) {
+  text(into, ': ');
+  renderType(into, typeInfo, options, t);
+}
+
+function renderType(into, typeInfo, options, t) {
+  if (t instanceof GraphQLNonNull) {
+    renderType(into, typeInfo, options, t.ofType);
+    text(into, '!');
+  } else if (t instanceof GraphQLList) {
+    text(into, '[');
+    renderType(into, typeInfo, options, t.ofType);
+    text(into, ']');
+  } else {
+    text(into, t.name, 'type-name', options, getTypeReference(typeInfo, t));
+  }
+}
+
+function renderDescription(into, options, def) {
+  const description = def.description;
+  if (description) {
+    const descriptionDiv = document.createElement('div');
+    descriptionDiv.className = 'info-description';
+    if (options.renderDescription) {
+      descriptionDiv.innerHTML = options.renderDescription(description);
+    } else {
+      descriptionDiv.appendChild(document.createTextNode(description));
+    }
+    into.appendChild(descriptionDiv);
+  }
+
+  renderDeprecation(into, options, def);
+}
+
+function renderDeprecation(into, options, def) {
+  const reason = def.deprecationReason;
+  if (reason) {
+    const deprecationDiv = document.createElement('div');
+    deprecationDiv.className = 'info-deprecation';
+    if (options.renderDescription) {
+      deprecationDiv.innerHTML = options.renderDescription(reason);
+    } else {
+      deprecationDiv.appendChild(document.createTextNode(reason));
+    }
+    const label = document.createElement('span');
+    label.className = 'info-deprecation-label';
+    label.appendChild(document.createTextNode('Deprecated: '));
+    deprecationDiv.insertBefore(label, deprecationDiv.firstChild);
+    into.appendChild(deprecationDiv);
+  }
+}
+
+function text(into, content, className, options, ref) {
+  if (className) {
+    const onClick = options.onClick;
+    const node = document.createElement(onClick ? 'a' : 'span');
+    if (onClick) {
+      // Providing a href forces proper a tag behavior, though we don't actually
+      // want clicking the node to navigate anywhere.
+      node.href = 'javascript:void 0'; // eslint-disable-line no-script-url
+      node.addEventListener('click', function (e) {
+        onClick(ref, e);
+      });
+    }
+    node.className = className;
+    node.appendChild(document.createTextNode(content));
+    into.appendChild(node);
+  } else {
+    into.appendChild(document.createTextNode(content));
+  }
+}

--- a/src/jump.js
+++ b/src/jump.js
@@ -1,0 +1,57 @@
+/* @flow */
+/**
+ *  Copyright (c) 2017, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+import CodeMirror from 'codemirror';
+
+import getTypeInfo from './utils/getTypeInfo';
+import {
+  getFieldReference,
+  getDirectiveReference,
+  getArgumentReference,
+  getTypeReference
+} from './utils/SchemaReference';
+import './utils/jump-addon';
+
+/**
+ * Registers GraphQL "jump" links for CodeMirror.
+ *
+ * When command-hovering over a token, this converts it to a link, which when
+ * pressed will call the provided onClick handler.
+ *
+ * Options:
+ *
+ *   - schema: GraphQLSchema provides positionally relevant info.
+ *   - onClick: A function called when a named thing is clicked.
+ *
+ */
+CodeMirror.registerHelper('jump', 'graphql', (token, options) => {
+  if (!options.schema || !options.onClick || !token.state) {
+    return;
+  }
+
+  // Given a Schema and a Token, produce a "SchemaReference" which refers to
+  // the particular artifact from the schema (such as a type, field, argument,
+  // or directive) that token references.
+  const state = token.state;
+  const kind = state.kind;
+  const step = state.step;
+  const typeInfo = getTypeInfo(options.schema, state);
+
+  if (kind === 'Field' && step === 0 && typeInfo.fieldDef ||
+      kind === 'AliasedField' && step === 2 && typeInfo.fieldDef) {
+    return getFieldReference(typeInfo);
+  } else if (kind === 'Directive' && step === 1 && typeInfo.directiveDef) {
+    return getDirectiveReference(typeInfo);
+  } else if (kind === 'Argument' && step === 0 && typeInfo.argDef) {
+    return getArgumentReference(typeInfo);
+  } else if (kind === 'NamedType' && step === 0 && typeInfo.type) {
+    return getTypeReference(typeInfo);
+  }
+});

--- a/src/utils/SchemaReference.js
+++ b/src/utils/SchemaReference.js
@@ -1,0 +1,95 @@
+/** @flow */
+/**
+ *  Copyright (c), Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+import type {
+  GraphQLArgument,
+  GraphQLDirective,
+  GraphQLField,
+  GraphQLNamedType,
+} from 'graphql';
+
+export type SchemaReference =
+  | FieldReference
+  | DirectiveReference
+  | ArgumentReference
+  | TypeReference;
+
+export type FieldReference = {
+  kind: 'Field',
+  field: GraphQLField,
+  type: ?GraphQLNamedType,
+};
+
+export type DirectiveReference = {
+  kind: 'Directive',
+  directive: GraphQLDirective,
+};
+
+export type ArgumentReference = {
+  kind: 'Argument',
+  argument: GraphQLArgument,
+  field?: GraphQLField,
+  type?: ?GraphQLNamedType,
+  directive?: GraphQLDirective,
+};
+
+export type TypeReference = {
+  kind: 'Type',
+  type: GraphQLNamedType,
+};
+
+export function getFieldReference(typeInfo: any): FieldReference {
+  return {
+    kind: 'Field',
+    schema: typeInfo.schema,
+    field: typeInfo.fieldDef,
+    type: isMetaField(typeInfo.fieldDef) ? null : typeInfo.parentType
+  };
+}
+
+export function getDirectiveReference(typeInfo: any): DirectiveReference {
+  return {
+    kind: 'Directive',
+    schema: typeInfo.schema,
+    directive: typeInfo.directiveDef,
+  };
+}
+
+export function getArgumentReference(typeInfo: any): ArgumentReference {
+  return typeInfo.directiveDef ? {
+    kind: 'Argument',
+    schema: typeInfo.schema,
+    argument: typeInfo.argDef,
+    directive: typeInfo.directiveDef
+  } : {
+    kind: 'Argument',
+    schema: typeInfo.schema,
+    argument: typeInfo.argDef,
+    field: typeInfo.fieldDef,
+    type: isMetaField(typeInfo.fieldDef) ? null : typeInfo.parentType
+  };
+}
+
+// Note: for reusability, getTypeReference can produce a reference to any type,
+// though it defaults to the current type.
+export function getTypeReference(
+  typeInfo: any,
+  type?: GraphQLNamedType
+): TypeReference {
+  return {
+    kind: 'Type',
+    schema: typeInfo.schema,
+    type: type || typeInfo.type
+  };
+}
+
+function isMetaField(fieldDef) {
+  return fieldDef.name.slice(0, 2) === '__';
+}

--- a/src/utils/getTypeInfo.js
+++ b/src/utils/getTypeInfo.js
@@ -28,6 +28,7 @@ import forEachState from './forEachState';
  */
 export default function getTypeInfo(schema, tokenState) {
   const info = {
+    schema,
     type: null,
     parentType: null,
     inputType: null,
@@ -110,6 +111,9 @@ export default function getTypeInfo(schema, tokenState) {
           info.objectFieldDefs[state.name] :
           null;
         info.inputType = objectField && objectField.type;
+        break;
+      case 'NamedType':
+        info.type = schema.getType(state.name);
         break;
     }
   });

--- a/src/utils/info-addon.js
+++ b/src/utils/info-addon.js
@@ -1,0 +1,164 @@
+/**
+ *  Copyright (c) 2017, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+import CodeMirror from 'codemirror';
+
+CodeMirror.defineOption('info', false, function (cm, options, old) {
+  if (old && old !== CodeMirror.Init) {
+    const oldOnMouseOver = cm.state.info.onMouseOver;
+    CodeMirror.off(cm.getWrapperElement(), 'mouseover', oldOnMouseOver);
+    clearTimeout(cm.state.info.hoverTimeout);
+    delete cm.state.info;
+  }
+
+  if (options) {
+    const state = cm.state.info = createState(options);
+    state.onMouseOver = onMouseOver.bind(null, cm);
+    CodeMirror.on(cm.getWrapperElement(), 'mouseover', state.onMouseOver);
+  }
+});
+
+function createState(options) {
+  return {
+    options:
+      options instanceof Function ? { render: options } :
+      options === true ? {} :
+      options
+  };
+}
+
+function getHoverTime(cm) {
+  const options = cm.state.info.options;
+  return options && options.hoverTime || 500;
+}
+
+function onMouseOver(cm, e) {
+  const state = cm.state.info;
+
+  const target = e.target || e.srcElement;
+  if (target.nodeName !== 'SPAN' || state.hoverTimeout !== undefined) {
+    return;
+  }
+
+  const box = target.getBoundingClientRect();
+
+  const hoverTime = getHoverTime(cm);
+  state.hoverTimeout = setTimeout(onHover, hoverTime);
+
+  const onMouseMove = function () {
+    clearTimeout(state.hoverTimeout);
+    state.hoverTimeout = setTimeout(onHover, hoverTime);
+  };
+
+  const onMouseOut = function () {
+    CodeMirror.off(document, 'mousemove', onMouseMove);
+    CodeMirror.off(cm.getWrapperElement(), 'mouseout', onMouseOut);
+    clearTimeout(state.hoverTimeout);
+    state.hoverTimeout = undefined;
+  };
+
+  const onHover = function () {
+    CodeMirror.off(document, 'mousemove', onMouseMove);
+    CodeMirror.off(cm.getWrapperElement(), 'mouseout', onMouseOut);
+    state.hoverTimeout = undefined;
+    onMouseHover(cm, box);
+  };
+
+  CodeMirror.on(document, 'mousemove', onMouseMove);
+  CodeMirror.on(cm.getWrapperElement(), 'mouseout', onMouseOut);
+}
+
+function onMouseHover(cm, box) {
+  const pos = cm.coordsChar({
+    left: (box.left + box.right) / 2,
+    top: (box.top + box.bottom) / 2
+  });
+
+  const state = cm.state.info;
+  const options = state.options;
+  const render = options.render || cm.getHelper(pos, 'info');
+  if (render) {
+    const token = cm.getTokenAt(pos, true);
+    if (token) {
+      const info = render(token, options, cm);
+      if (info) {
+        showPopup(cm, box, info);
+      }
+    }
+  }
+}
+
+function showPopup(cm, box, info) {
+  const popup = document.createElement('div');
+  popup.className = 'CodeMirror-info';
+  popup.appendChild(info);
+  document.body.appendChild(popup);
+
+  const popupBox = popup.getBoundingClientRect();
+  const popupStyle = popup.currentStyle || window.getComputedStyle(popup);
+  const popupWidth =
+    popupBox.right - popupBox.left +
+    parseFloat(popupStyle.marginLeft) +
+    parseFloat(popupStyle.marginRight);
+  const popupHeight =
+    popupBox.bottom - popupBox.top +
+    parseFloat(popupStyle.marginTop) +
+    parseFloat(popupStyle.marginBottom);
+
+  let topPos = box.bottom;
+  if (popupHeight > window.innerHeight - box.bottom - 15 &&
+      box.top > window.innerHeight - box.bottom) {
+    topPos = box.top - popupHeight;
+  }
+
+  if (topPos < 0) {
+    topPos = box.bottom;
+  }
+
+  let leftPos = Math.max(0, window.innerWidth - popupWidth - 15);
+  if (leftPos > box.left) {
+    leftPos = box.left;
+  }
+
+  popup.style.opacity = 1;
+  popup.style.top = topPos + 'px';
+  popup.style.left = leftPos + 'px';
+
+  let popupTimeout;
+
+  const onMouseOverPopup = function () {
+    clearTimeout(popupTimeout);
+  };
+
+  const onMouseOut = function () {
+    clearTimeout(popupTimeout);
+    popupTimeout = setTimeout(hidePopup, 200);
+  };
+
+  const hidePopup = function () {
+    CodeMirror.off(popup, 'mouseover', onMouseOverPopup);
+    CodeMirror.off(popup, 'mouseout', onMouseOut);
+    CodeMirror.off(cm.getWrapperElement(), 'mouseout', onMouseOut);
+
+    if (popup.style.opacity) {
+      popup.style.opacity = 0;
+      setTimeout(function () {
+        if (popup.parentNode) {
+          popup.parentNode.removeChild(popup);
+        }
+      }, 600);
+    } else if (popup.parentNode) {
+      popup.parentNode.removeChild(popup);
+    }
+  };
+
+  CodeMirror.on(popup, 'mouseover', onMouseOverPopup);
+  CodeMirror.on(popup, 'mouseout', onMouseOut);
+  CodeMirror.on(cm.getWrapperElement(), 'mouseout', onMouseOut);
+}

--- a/src/utils/jump-addon.js
+++ b/src/utils/jump-addon.js
@@ -1,0 +1,149 @@
+/**
+ *  Copyright (c) 2017, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+import CodeMirror from 'codemirror';
+
+CodeMirror.defineOption('jump', false, function (cm, options, old) {
+  if (old && old !== CodeMirror.Init) {
+    const oldOnMouseOver = cm.state.jump.onMouseOver;
+    CodeMirror.off(cm.getWrapperElement(), 'mouseover', oldOnMouseOver);
+    const oldOnMouseOut = cm.state.jump.onMouseOut;
+    CodeMirror.off(cm.getWrapperElement(), 'mouseout', oldOnMouseOut);
+    CodeMirror.off(document, 'keydown', cm.state.jump.onKeyDown);
+    delete cm.state.jump;
+  }
+
+  if (options) {
+    const state = cm.state.jump = {
+      options,
+      onMouseOver: onMouseOver.bind(null, cm),
+      onMouseOut: onMouseOut.bind(null, cm),
+      onKeyDown: onKeyDown.bind(null, cm),
+    };
+
+    CodeMirror.on(cm.getWrapperElement(), 'mouseover', state.onMouseOver);
+    CodeMirror.on(cm.getWrapperElement(), 'mouseout', state.onMouseOut);
+    CodeMirror.on(document, 'keydown', state.onKeyDown);
+  }
+});
+
+function onMouseOver(cm, event) {
+  const target = event.target || event.srcElement;
+  if (target.nodeName !== 'SPAN') {
+    return;
+  }
+
+  const box = target.getBoundingClientRect();
+  const cursor = {
+    left: (box.left + box.right) / 2,
+    top: (box.top + box.bottom) / 2
+  };
+
+  cm.state.jump.cursor = cursor;
+
+  if (cm.state.jump.isHoldingModifier) {
+    enableJumpMode(cm);
+  }
+}
+
+function onMouseOut(cm) {
+  if (!cm.state.jump.isHoldingModifier && cm.state.jump.cursor) {
+    cm.state.jump.cursor = null;
+    return;
+  }
+
+  if (cm.state.jump.isHoldingModifier && cm.state.jump.marker) {
+    disableJumpMode(cm);
+  }
+}
+
+function onKeyDown(cm, event) {
+  if (cm.state.jump.isHoldingModifier || !isJumpModifier(event.key)) {
+    return;
+  }
+
+  cm.state.jump.isHoldingModifier = true;
+
+  if (cm.state.jump.cursor) {
+    enableJumpMode(cm);
+  }
+
+  const onKeyUp = upEvent => {
+    if (upEvent.code !== event.code) {
+      return;
+    }
+
+    cm.state.jump.isHoldingModifier = false;
+
+    if (cm.state.jump.marker) {
+      disableJumpMode(cm);
+    }
+
+    CodeMirror.off(document, 'keyup', onKeyUp);
+    CodeMirror.off(document, 'click', onClick);
+    cm.off('mousedown', onMouseDown);
+  };
+
+  const onClick = clickEvent => {
+    const destination = cm.state.jump.destination;
+    if (destination) {
+      cm.state.jump.options.onClick(destination, clickEvent);
+    }
+  };
+
+  const onMouseDown = (_, downEvent) => {
+    if (cm.state.jump.destination) {
+      downEvent.codemirrorIgnore = true;
+    }
+  };
+
+  CodeMirror.on(document, 'keyup', onKeyUp);
+  CodeMirror.on(document, 'click', onClick);
+  cm.on('mousedown', onMouseDown);
+}
+
+const isMac = navigator && navigator.appVersion.indexOf('Mac') !== -1;
+
+function isJumpModifier(key) {
+  return key === (isMac ? 'Meta' : 'Control');
+}
+
+function enableJumpMode(cm) {
+  if (cm.state.jump.marker) {
+    return;
+  }
+
+  const cursor = cm.state.jump.cursor;
+  const pos = cm.coordsChar(cursor);
+  const token = cm.getTokenAt(pos, true);
+
+  const options = cm.state.jump.options;
+  const getDestination = options.getDestination || cm.getHelper(pos, 'jump');
+  if (getDestination) {
+    const destination = getDestination(token, options, cm);
+    if (destination) {
+      const marker = cm.markText(
+        { line: pos.line, ch: token.start },
+        { line: pos.line, ch: token.end },
+        { className: 'CodeMirror-jump-token' }
+      );
+
+      cm.state.jump.marker = marker;
+      cm.state.jump.destination = destination;
+    }
+  }
+}
+
+function disableJumpMode(cm) {
+  const marker = cm.state.jump.marker;
+  cm.state.jump.marker = null;
+  cm.state.jump.destination = null;
+
+  marker.clear();
+}


### PR DESCRIPTION
**Info**

When hovering over a token in the query, produces a tooltip with some information about the thing you're hovering over.

This can be really helpful when you're reading through a query and trying to figure out what the current type is, what type an argument accepts, or descriptions of any of those things.

**Jump**

When holding down Command (Mac) or Control (Win) then tokens in the editor become clickable links. Clicking a link can then call a function with relevant schema data referenced, so the editor can do something useful. For example, in GraphiQL we can automatically expose the Documentation explorer to show more about it.