### PR TITLE
Guard against unset `state.rule`

### DIFF
--- a/src/utils/onlineParser.js
+++ b/src/utils/onlineParser.js
@@ -44,7 +44,7 @@ function getToken(stream, state, options) {
   const { LexRules, ParseRules, eatWhitespace, editorConfig } = options;
 
   // Restore state after an empty-rule.
-  if (state.rule.length === 0) {
+  if (state.rule && state.rule.length === 0) {
     popRule(state);
   } else if (state.needsAdvance) {
     state.needsAdvance = false;


### PR DESCRIPTION
Some kinds of bad JSON were causing an exception here. Example:

    {}garbage

would cause `state.rule.length` to blow up with:

    Uncaught TypeError: Cannot read property 'length' of undefined

This applies the same fix that already exists in graphql-language-service (and is another reason why this common code should be factored out into a package that both codemirror-graphql and graphql-language-service can depend on; will have PRs up for that soon).