### PR TITLE
Silence eslint deprecation warning

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -40,8 +40,6 @@
   },
 
   "rules": {
-    "babel/no-await-in-loop": 2,
-
     "flowtype/space-after-type-colon": [2, "always"],
     "flowtype/space-before-type-colon": [2, "never"],
     "flowtype/space-before-generic-bracket": [2, "never"],
@@ -93,6 +91,7 @@
     "new-parens": 2,
     "newline-after-var": 0,
     "no-alert": 2,
+    "no-await-in-loop": 2,
     "no-array-constructor": 2,
     "no-bitwise": 0,
     "no-caller": 2,


### PR DESCRIPTION
    The babel/no-await-in-loop rule is deprecated. Please use the built
    in no-await-in-loop rule instead.