### PR TITLE
Go back to specifying peer dependencies more liberally

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "peerDependencies": {
     "codemirror": "^5.26.0",
-    "graphql": "^0.10.0"
+    "graphql": "^0.6.0 || ^0.7.0 || ^0.8.0-b || ^0.8.0 || ^0.9.0 || ^0.10.0"
   },
   "dependencies": {
     "graphql-language-service-interface": "0.0.16",


### PR DESCRIPTION
Greenkeeper has a habit of making this narrower than we want/need.