### PR TITLE
Better custom scalar validation

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -201,7 +201,7 @@
     "prefer-reflect": 0,
     "prefer-spread": 0,
     "quote-props": [2, "as-needed", {"numbers": true}],
-    "quotes": [2, "single"],
+    "quotes": [2, "single", {"avoidEscape": true}],
     "radix": 2,
     "require-yield": 2,
     "semi": [2, "always"],

--- a/src/__tests__/testSchema.js
+++ b/src/__tests__/testSchema.js
@@ -13,6 +13,7 @@ import {
   GraphQLUnionType,
   GraphQLInterfaceType,
   GraphQLEnumType,
+  GraphQLScalarType,
   GraphQLInputObjectType,
   GraphQLBoolean,
   GraphQLInt,
@@ -28,6 +29,34 @@ import {
 } from 'graphql';
 
 // Test Schema
+
+const TestCustom = new GraphQLScalarType({
+  name: 'TestCustom',
+  serialize: value => value,
+  parseValue: value => {
+    if (value && value.length && value[0] === 'b') {
+      return value;
+    }
+    return null;
+  },
+  parseLiteral: ast => {
+    if (ast.value && ast.value.length && ast.value[0] === 'b') {
+      return ast.value;
+    }
+    return undefined;
+  },
+});
+
+const TestThrowingCustom = new GraphQLScalarType({
+  name: 'TestThrowingCustom',
+  serialize: value => value,
+  parseValue: () => {
+    throw new Error('Oups');
+  },
+  parseLiteral: () => {
+    throw new Error('Oups');
+  },
+});
 
 const TestEnum = new GraphQLEnumType({
   name: 'TestEnum',
@@ -145,6 +174,8 @@ const TestType = new GraphQLObjectType({
         boolean: {type: GraphQLBoolean},
         id: {type: GraphQLID},
         enum: {type: TestEnum},
+        custom: {type: TestCustom},
+        throwingCustom: {type: TestThrowingCustom},
         object: {type: TestInputObject},
         // List
         listString: {type: new GraphQLList(GraphQLString)},

--- a/src/variables/__tests__/lint-test.js
+++ b/src/variables/__tests__/lint-test.js
@@ -72,6 +72,69 @@ describe('graphql-variables-lint', () => {
     });
   });
 
+  it('catches enum validation errors', async () => {
+    const errors = await printLintErrors(
+      'query ($foo: TestEnum) { f }',
+      ' { "foo": "NaN" }',
+    );
+
+    expect(errors[0]).to.deep.equal({
+      message: 'Expected value of type "TestEnum".',
+      severity: 'error',
+      type: 'validation',
+      from: {line: 0, ch: 10, sticky: null},
+      to: {line: 0, ch: 15, sticky: null},
+    });
+  });
+
+  it("doesn't throw an error on valid enum", async () => {
+    const errors = await printLintErrors(
+      'query ($foo: TestEnum) { f }',
+      ' { "foo": "RED" }',
+    );
+
+    expect(errors).to.have.lengthOf(0);
+  });
+
+  it('catches custom scalar (returning undefined) validation errors', async () => {
+    const errors = await printLintErrors(
+      'query ($foo: TestCustom) { f }',
+      ' { "foo": "doesntstartwithb" }',
+    );
+
+    expect(errors[0]).to.deep.equal({
+      message: 'Expected value of type "TestCustom".',
+      severity: 'error',
+      type: 'validation',
+      from: {line: 0, ch: 10, sticky: null},
+      to: {line: 0, ch: 28, sticky: null},
+    });
+  });
+
+  it('catches custom scalar (throwing an error) validation errors', async () => {
+    const errors = await printLintErrors(
+      'query ($foo: TestThrowingCustom) { f }',
+      ' { "foo": "doesntstartwithb" }',
+    );
+
+    expect(errors[0]).to.deep.equal({
+      message: 'Oups',
+      severity: 'error',
+      type: 'validation',
+      from: {line: 0, ch: 10, sticky: null},
+      to: {line: 0, ch: 28, sticky: null},
+    });
+  });
+
+  it("doesn't throw an error on valid custom scalar", async () => {
+    const errors = await printLintErrors(
+      'query ($foo: TestCustom) { f }',
+      ' { "foo": "bar" }',
+    );
+
+    expect(errors).to.have.lengthOf(0);
+  });
+
   it('reports unknown variable names', async () => {
     const errors = await printLintErrors(
       'query ($foo: Int) { f }',

--- a/src/variables/lint.js
+++ b/src/variables/lint.js
@@ -162,7 +162,7 @@ function validateValue(type, valueAST) {
     return [[valueAST, `Expected value of type "${type}".`]];
   }
 
-  // Validate enums and custom scalars.
+  // Validate enums.
   if (type instanceof GraphQLEnumType) {
     if (
       (valueAST.kind !== 'String' &&
@@ -175,7 +175,7 @@ function validateValue(type, valueAST) {
     }
   }
 
-  // Validate enums and custom scalars.
+  // Validate custom scalars.
   if (type instanceof GraphQLScalarType) {
     try {
       if (type.parseLiteral(valueAST) === undefined) {

--- a/src/variables/lint.js
+++ b/src/variables/lint.js
@@ -163,7 +163,7 @@ function validateValue(type, valueAST) {
   }
 
   // Validate enums and custom scalars.
-  if (type instanceof GraphQLEnumType || type instanceof GraphQLScalarType) {
+  if (type instanceof GraphQLEnumType) {
     if (
       (valueAST.kind !== 'String' &&
         valueAST.kind !== 'Number' &&
@@ -172,6 +172,17 @@ function validateValue(type, valueAST) {
       isNullish(type.parseValue(valueAST.value))
     ) {
       return [[valueAST, `Expected value of type "${type}".`]];
+    }
+  }
+
+  // Validate enums and custom scalars.
+  if (type instanceof GraphQLScalarType) {
+    try {
+      if (type.parseLiteral(valueAST) === undefined) {
+        return [[valueAST, `Expected value of type "${type}".`]];
+      }
+    } catch (err) {
+      return [[valueAST, err.message || err]];
     }
   }
 


### PR DESCRIPTION
- Use parseLiteral to validate the custom scalar. Should work with validation changes introduced in graphql-js v12: https://github.com/graphql/graphql-js/pull/1104
- Fix linting rule conflicting with pretty-check