### PR TITLE
Allow graphql 0.13 as peer dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "peerDependencies": {
     "codemirror": "^5.26.0",
-    "graphql": "^0.10.0 || ^0.11.0 || ^0.12.0"
+    "graphql": "^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0"
   },
   "dependencies": {
     "graphql-language-service-interface": "^1.0.18",
@@ -83,7 +83,7 @@
     "eslint-plugin-babel": "4.1.2",
     "eslint-plugin-flowtype": "2.35.0",
     "flow-bin": "^0.56.0",
-    "graphql": "^0.12.3",
+    "graphql": "^0.13.0",
     "jsdom": "^11.2.0",
     "mocha": "3.5.0",
     "prettier": "^1.4.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -706,8 +706,8 @@ code-point-at@^1.0.0:
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
 
 codemirror@^5.28.0:
-  version "5.30.0"
-  resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.30.0.tgz#86e57dd5ea5535acbcf9c720797b4cefe05b5a70"
+  version "5.35.0"
+  resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.35.0.tgz#280653d495455bc66aa87e6284292b02775ba878"
 
 color-convert@^1.9.0:
   version "1.9.0"
@@ -1281,6 +1281,12 @@ graphql@^0.12.3:
   dependencies:
     iterall "1.1.3"
 
+graphql@^0.13.0:
+  version "0.13.1"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-0.13.1.tgz#9b3db3d8e40d1827e4172404bfdd2e4e17a58b55"
+  dependencies:
+    iterall "^1.2.0"
+
 growl@1.9.2:
   version "1.9.2"
   resolved "https://registry.yarnpkg.com/growl/-/growl-1.9.2.tgz#0ea7743715db8d8de2c5ede1775e1b45ac85c02f"
@@ -1529,6 +1535,10 @@ isstream@~0.1.2:
 iterall@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.1.3.tgz#1cbbff96204056dde6656e2ed2e2226d0e6d72c9"
+
+iterall@^1.2.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.2.1.tgz#59a347ae8001d2d4bc546b8487ca755d61849965"
 
 js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"


### PR DESCRIPTION
Also updates graphql + codemirror for the tests.