### PR TITLE
monorepo notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 GraphQL mode for CodeMirror
 ===========================
 
+
+> ⚠️NOTICE!⚠️ This repository is about to be archived and join a monorepo.  Please make new PRs against the [ide-monorepo branch](https://github.com/graphql/graphiql/tree/ide-monorepo)
+
 [![Build Status](https://travis-ci.org/graphql/codemirror-graphql.svg?branch=master)](https://travis-ci.org/graphql/codemirror-graphql)
 
 Provides CodeMirror with a parser mode for GraphQL along with a live linter and


### PR DESCRIPTION
Just a warning to contributors! Merge will happen during GraphiQL WG meeting on tuesday (we are hoping to rename the graphiql repository to ide, so github.org/graphql/ide, and the WG to the GraphQL IDE WG, we will wait til tuesday to make that call)